### PR TITLE
docs: 현재 구현 기준으로 README와 기술 문서 개편

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,335 +1,198 @@
-# 🛒 E-Shop : 정합성과 조회 가용성을 동시에 지켜낸 백엔드
+<div align="center">
 
-> 주문 정합성과 조회 가용성을 함께 검증하고, 멱등성·조회 최적화·운영 보강까지 반영한 Spring Boot 기반 이커머스 백엔드 프로젝트입니다.
-> 락을 걸어서 데이터 정합성을 맞추는 건 기본입니다. 하지만 락 때문에 다른 유저들의 조회 화면까지 멈춘다면 좋은 설계일까요?"
+# E-Shop
 
-![Java](https://img.shields.io/badge/Java-21-orange?logo=java)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.3.0-green?logo=springboot)
-![Redis](https://img.shields.io/badge/Redis-Redisson-red?logo=redis)
-![QueryDSL](https://img.shields.io/badge/QueryDSL-5.1.0-lightgrey)
+### 동시 주문의 재고 정합성과 주문 폭주 상황의 조회 가용성을 함께 다루는 이커머스 백엔드
+
+[![Build and Publish Image](https://github.com/juhwanz/eshop-refac/actions/workflows/deploy.yml/badge.svg)](https://github.com/juhwanz/eshop-refac/actions/workflows/deploy.yml)
+[![Secret Scan](https://github.com/juhwanz/eshop-refac/actions/workflows/secret-scan.yml/badge.svg)](https://github.com/juhwanz/eshop-refac/actions/workflows/secret-scan.yml)
+![Java](https://img.shields.io/badge/Java-21-E76F00?logo=openjdk&logoColor=white)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.3.0-6DB33F?logo=springboot&logoColor=white)
+![MySQL](https://img.shields.io/badge/MySQL-8.0-4479A1?logo=mysql&logoColor=white)
+![Redis](https://img.shields.io/badge/Redis-Redisson-DC382D?logo=redis&logoColor=white)
+
+[핵심 설계](#핵심-설계) · [빠른 시작](#빠른-시작) · [API](#api-요약) · [테스트](#테스트와-ci) · [상세 문서](#상세-문서)
+
+</div>
 
 ## 프로젝트 소개
 
-이 프로젝트는 단순한 쇼핑몰 CRUD 구현보다, **트래픽이 몰릴 때 실제로 문제가 되는 지점**을 개선하는 데 초점을 맞췄습니다.
-### 핵심 성과 
+E-Shop은 CRUD 기능의 수보다 **트래픽이 몰릴 때 어떤 불변조건을 지켜야 하는가**에 집중한 Spring Boot 기반 백엔드 프로젝트입니다.
 
-* **주문 정합성 방어:** 동시 주문 45건 / 재고 40개 -> **성공 40건, 실패 5건, 남은 재고 0**
-* **조회 가용성 방어:** (주문 폭주 락 대기 중, 단순 조회 20건 발생 시)
-  *  DB 비관적 락 적용 시: **조회 성공 0건, 실패 20건** (커넥션 고갈로 인한 타임아웃)
-  *  Redis 분산 락 전환 시: **조회 성공 20건, 실패 0건** (DB 커넥션 점유 최소화로 정상 응답)
-     아래 수치는 테스트 로그 기준이며, 실행 환경에 따라 절대값은 달라질 수 있습니다.
-핵심 질문은 네 가지였습니다.
+- 동시에 같은 상품을 주문해도 실제 재고보다 많이 판매하지 않습니다.
+- 분산 락 대기를 DB 트랜잭션 밖에 두어 커넥션 점유 시간을 줄입니다.
+- 동일 주문 요청은 사용자별 멱등성 키로 중복 처리를 방지합니다.
+- 대기열, 캐시, 깊은 페이지 조회처럼 트래픽 증가 후 드러나는 문제를 함께 다룹니다.
+- 보안 검사와 안전한 테스트 범위를 CI에서 자동 검증합니다.
 
-- 동시에 같은 상품을 주문해도 **재고가 정확하게 유지되는가**
-- 락 경쟁이 심해질 때도 **조회 요청이 살아남는가**
-- 상품 수가 많아져도 **깊은 페이지 조회가 급격히 느려지지 않는가**
-- 캐시를 붙인 뒤에도 **수정 직후 최신 데이터 정합성이 보장되는가**
+> 이 문서는 2026-09-04 기준 구현 상태를 설명합니다. 진행 중인 개선 순서는 [로드맵 #27](https://github.com/juhwanz/eshop-refac/issues/27)에서 관리합니다.
 
-이를 해결하기 위해 다음 구조를 적용했습니다.
+## 핵심 설계
 
-- **주문 정합성**: Redis 분산 락 + `RedissonLockStockFacade`
-- **조회 가용성**: 락 대기를 DB 바깥으로 분리해 DB 커넥션 점유 최소화
-- **유량 제어**: Redis ZSet 대기열 + TTL 기반 활성 토큰
-- **대용량 조회 성능**: QueryDSL 기반 No-Offset 페이지네이션 + `Slice`
-- **주문 조회 최적화**: `default_batch_fetch_size=100`으로 N+1 완화
-- **캐시 정합성**: `@TransactionalEventListener(AFTER_COMMIT)` 기반 캐시 무효화
+| 관심사 | 현재 구현 | 지키려는 조건 |
+|---|---|---|
+| 재고 동시성 | 상품별 Redisson 분산 락 | 재고가 음수가 되거나 초과 판매되지 않음 |
+| 트랜잭션 경계 | 락 획득 후 `OrderService` 트랜잭션 진입 | 락 대기 중 DB 커넥션을 점유하지 않음 |
+| 주문 멱등성 | Redis `setIfAbsent`, 처리 상태 및 응답 TTL | 완료 요청은 기존 응답 반환, 실패 요청은 재시도 허용 |
+| 유량 제어 | Redis ZSet 대기열과 TTL 활성 토큰 | 허용된 사용자만 주문 생성 경로 진입 |
+| 캐시 정합성 | `AFTER_COMMIT` 이벤트 기반 상품 캐시 제거 | DB 롤백 시 캐시를 먼저 제거하지 않음 |
+| 상품 조회 | QueryDSL Offset `Page` + No-Offset `Slice` | 페이지 이동과 커서 조회 요구를 분리 |
+| 주문 조회 | `default_batch_fetch_size=100` | 컬렉션 fetch join 기반 메모리 페이징 회피 |
+| 인증 | Stateless JWT, Refresh Token Rotation, Redis blacklist | 토큰 재사용과 로그아웃 토큰 접근 방지 |
 
-## 핵심 개선 포인트
+```mermaid
+flowchart LR
+    Client[Client] --> Security[JWT / Spring Security]
+    Security --> Queue[QueueInterceptor]
+    Queue --> Idempotency[Redis idempotency key]
+    Idempotency --> Lock[Redisson product lock]
+    Lock --> Service[Order transaction]
+    Service --> MySQL[(MySQL)]
+    Service --> Event[ProductCacheEvictEvent]
+    Event -->|AFTER_COMMIT| Redis[(Redis)]
 
-### 1. Redis 분산 락과 멱등성 키로 주문 정합성과 중복 요청을 함께 제어
-주문 생성은 QueueInterceptor 통과 후, OrderController -> OrderIdempotencyService -> RedissonLockStockFacade -> OrderService 흐름으로 처리됩니다.
-락 획득/해제는 파사드에서 담당하고, 실제 주문 트랜잭션은 서비스에서 짧게 수행하도록 분리했습니다. 분산 락 획득 실패 시에도 대기열 상태를 즉시 제거하지 않도록 하여, 사용자가 재진입 과정을 반복하지 않고 다시 요청할 수 있게 설계했습니다.
+    Redis -. waiting queue .-> Queue
+    Redis -. cached response .-> Idempotency
+```
 
-### 2. 대기열을 ZSet와 활성 토큰으로 분리
-`WaitingQueueService`는 다음 두 키를 사용합니다.
-
-- `waiting_queue` : 대기 순서를 관리하는 ZSet
-- `active_user:{userId}` : 진입 허용 여부를 확인하는 TTL 600초 String 키
-
-이 구조 덕분에 주문 요청 시 인터셉터는 `hasKey()` 기반으로 빠르게 진입 여부를 검사할 수 있습니다.
-
-### 3. 주문 목록 조회는 Fetch Join 대신 Batch Fetch 사용
-컬렉션 Fetch Join과 페이징을 함께 쓰면 Hibernate가 메모리 페이징으로 전환될 수 있습니다.  
-이 프로젝트는 `default_batch_fetch_size=100`을 적용해, 현재 데이터 규모와 응답 패턴 기준에서 주문 조회의 페이징 안정성을 유지하면서 N+1 문제를 완화했습니다.
-
-### 4. 상품 목록은 Offset과 No-Offset을 모두 제공
-- `GET /api/products/search` : Offset 기반 `Page`
-- `GET /api/products/search/no-offset` : No-Offset 기반 `Slice`
-
-운영성 측면에서 전통적인 페이지 이동과 스크롤형 조회를 모두 비교할 수 있게 분리했습니다.
-
-### 5. 캐시는 조회 속도뿐 아니라 정합성까지 검증
-상품 단건 조회는 `@Cacheable("products")`를 사용하고, 수정/재고 변경 시에는 이벤트를 발행한 뒤 `AFTER_COMMIT` 시점에 캐시를 제거합니다.  
-즉, 트랜잭션이 롤백되면 캐시 무효화도 실행되지 않도록 구성했습니다.
+주문 처리 순서와 각 경계의 선택 이유는 [아키텍처 상세](docs/architecture.md)에 정리했습니다.
 
 ## 기술 스택
 
 | 구분 | 기술 |
 |---|---|
 | Language | Java 21 |
-| Framework | Spring Boot 3.3.0, Spring Web, Spring Data JPA, Spring Security, Validation |
-| Database | MySQL |
-| Cache / Lock | Redis, Redisson, ShedLock |
-| Query | QueryDSL 5.1.0 |
-| Auth | JWT |
-| Test | JUnit 5, Spring Boot Test, Spring Security Test, H2|
-| Docs | SpringDoc OpenAPI |
-| Infra | Docker, Docker Compose, GitHub Actions, Nginx 기반 배포 스크립트 |
-
-## 아키텍처
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant Interceptor as QueueInterceptor
-    participant Redis as Redis(Queue/Lock)
-    participant Facade as RedissonLockStockFacade
-    participant Service as OrderService
-    participant DB as MySQL
-
-    User->>Interceptor: POST /api/orders
-    Interceptor->>Redis: active_user:{userId} 확인
-    alt 진입 불가
-        Interceptor-->>User: 429 Too Many Requests
-    else 진입 가능
-				Interceptor-->>User: 통과
-				User->>OrderController: POST /api/orders
-				OrderController->>OrderIdempotencyService: process(...)
-				OrderIdempotencyService->>RedissonLockStockFacade: order(...)
-        Facade->>Redis: 상품 단위 분산 락 획득
-        alt 락 획득 성공
-            Facade->>Service: 주문 트랜잭션 실행
-            Service->>DB: 재고 차감 + 주문 저장
-            Service-->>Facade: 커밋
-            Facade->>Redis: 락 해제 + 활성 토큰 제거
-            Facade-->>User: 201 Created
-        else 락 획득 실패
-            Facade-->>User: 503 Service Unavailable
-        end
-    end
-```
+| Application | Spring Boot 3.3.0, Spring Web, Validation |
+| Persistence | Spring Data JPA, Hibernate, QueryDSL 5.1.0, Flyway |
+| Database | MySQL 8.0, H2(test) |
+| Redis | Spring Data Redis, Redisson 3.31.0, ShedLock 5.13.0 |
+| Security | Spring Security, JWT(JJWT 0.11.5) |
+| Observability | Spring Boot Actuator, Micrometer |
+| API Docs | SpringDoc OpenAPI 2.6.0 |
+| Build & Delivery | Gradle Wrapper, Docker, Docker Compose, GitHub Actions |
 
 ## 주요 기능
 
-### 사용자
-- 회원가입
-- 로그인
-- Access Token / Refresh Token 발급 및 RTR(Refresh Token Rotation) 방식 재발급
-- Refresh Token Redis 저장(`RT:{email}`, TTL 14일) 및 로그아웃 시 무효화 처리
-- 로그아웃 시에는 Refresh Token 삭제와 Access Token 블랙리스트 등록을 수행
+- **사용자**: 회원가입, 로그인, Access/Refresh Token 발급, RTR 재발급, 로그아웃과 Access Token blacklist
+- **상품**: 등록, 단건 캐시 조회, 조건 검색, No-Offset 조회, 가격 수정
+- **주문**: 멱등 주문 생성, 사용자별 주문 목록, 소유권 검증을 포함한 주문 취소
+- **대기열**: Redis ZSet 등록, 1초마다 최대 100명 활성화, ShedLock 기반 중복 스케줄 방지
 
-### 상품
-- 상품 등록
-- 상품 단건 조회
-- 조건 검색
-- No-Offset 스크롤 검색
-- 가격 수정
-- 상품 단건 조회 캐시
+## 빠른 시작
 
-### 주문
-- 주문 생성 (Idempotency-Key + Redis 분산 락 적용)
-- 내 주문 목록 조회 ( Batch Fetch Size 최적화)
-- 주문 취소 (주문 생성과 동일하게 Redis 분산 락을 통한 재고 복구 정합성 보장)
+### 요구사항
 
-### 대기열
-- 대기열 등록 API 제공 (PoC)
-- 스케줄러가 1초마다 최대 100명 진입 허용
-- 주문 POST 요청에서 대기열 통과 여부 검사
-- 다중 서버 환경에서 스케줄러 중복 실행을 방지하기 위해 **ShedLock** 적용
-
-## API 요약
-
-| Method | Path                              | 설명               | 비고                                                                                            |
-|---|-----------------------------------|------------------|-----------------------------------------------------------------------------------------------|
-| POST | `/api/users/signup`               | 회원가입             | 공개                                                                                            |
-| POST | `/api/users/login`                | 로그인              | 공개                                                                                            |
-| POST | `/api/users/reissue`              | 토큰 재발급           | Access Token 만료 시 Refresh Token으로 요청                                                          |
-| POST | `/api/users/logout`               | 로그아웃             | JWT 필요, Redis 내 Refresh Token 삭제 및 Access Token 블랙리스트 등록                                      |
-| GET | `/api/products/{productId}`       | 상품 단건 조회         | 공개                                                                                            |
-| GET | `/api/products/search`            | 상품 검색(Page)      | 공개                                                                                            |
-| GET | `/api/products/search/no-offset`  | 상품 스크롤 검색(Slice) | 공개                                                                                            |
-| POST | `/api/products`                   | 상품 등록            | `ADMIN` 권한 필요                                                                                 |
-| PATCH | `/api/products/{productId}/price` | 상품 가격 수정         | `ADMIN` 권한 필요                                                                                 |
-| POST | `/api/orders`                     | 주문 생성            | JWT 필요, 대기열 통과 필요, Idempotency-Key 헤더 필요                                                                           |
-| GET | `/api/orders`                     | 내 주문 목록 조회       | JWT 필요                                                                                        |
-| PATCH | `/api/orders/{orderId}/cancel`    | 주문 취소            | JWT 필요                                                                                        |
-| POST | `/api/orders/queue` | 대기열 등록(PoC) | `dev/test/local` 전용, 인증 사용자 기준 |
-
-Swagger UI는 `/swagger-ui.html` 경로로 확인할 수 있습니다.
-
-## 실행 방법
-
-### 1) 사전 준비
 - Java 21
-- Docker / Docker Compose
-- MySQL 8
-- Redis
+- Docker와 Docker Compose
 
-### 2) 환경 변수
-민감 정보는 코드에 하드코딩하지 않고, 애플리케이션 실행 전 환경 변수로 주입해야 합니다.
+### 1. 환경변수 준비
 
 ```bash
-export DB_USERNAME=your_db_username
-export DB_PASSWORD=your_db_password
-export JWT_SECRET_KEY=your_base64_encoded_jwt_secret
+cp .env.example .env
 ```
 
-운영 환경의 자격 증명 교체와 유출 대응 절차는 [자격 증명 관리 문서](docs/security/credential-management.md)를 참고하세요.
+`.env`에 로컬 환경 값을 설정합니다. 실제 비밀값은 Git에 추가하지 않습니다.
 
-### 3) 로컬 인프라 실행
-`docker-compose.yml`에는 MySQL과 Redis가 포함되어 있습니다.
+```dotenv
+DB_USERNAME=root
+DB_PASSWORD=change-me
+JWT_SECRET_KEY=base64-encoded-random-key
+```
+
+### 2. MySQL과 Redis 실행
 
 ```bash
 docker compose up -d mysql redis
 ```
 
-### 4) 애플리케이션 실행
+### 3. 환경변수 로드 후 애플리케이션 실행
+
 ```bash
+set -a
+source .env
+set +a
 ./gradlew bootRun --args='--spring.profiles.active=local'
 ```
 
-또는 빌드 후 실행할 수 있습니다.
+- Swagger UI: <http://localhost:8080/swagger-ui.html>
+- Health endpoint: <http://localhost:8080/actuator/health> (현재 정책상 JWT 인증 필요)
 
-```bash
-./gradlew clean build
-java -jar build/libs/eshop-refact-0.0.1-SNAPSHOT.jar --spring.profiles.active=local
-```
+로컬 Compose의 `mysql-data/`는 개발자 런타임 데이터이며 Git에서 추적하지 않습니다. 자격 증명 원칙과 유출 대응은 [보안 문서](docs/security/credential-management.md)를 참고하세요.
 
-## 테스트 및 검증
+## API 요약
 
-아래 수치는 첨부된 테스트 로그 기준입니다. 실행 시점과 환경에 따라 절대값은 달라질 수 있지만, **비교 방향성과 결과 해석**은 코드와 로그에서 동일하게 확인됩니다.
+| Method | Path | 인증 | 설명 |
+|---|---|---|---|
+| `POST` | `/api/users/signup` | 공개 | 회원가입 |
+| `POST` | `/api/users/login` | 공개 | Access/Refresh Token 발급 |
+| `POST` | `/api/users/reissue` | 공개 | Refresh Token 검증 및 RTR 재발급 |
+| `POST` | `/api/users/logout` | 사용자 | Refresh Token 제거 및 Access Token blacklist |
+| `GET` | `/api/products/{productId}` | 공개 | 상품 단건 조회 |
+| `GET` | `/api/products/search` | 공개 | 조건 검색과 Offset 페이지 조회 |
+| `GET` | `/api/products/search/no-offset` | 공개 | 내림차순 커서 기반 `Slice` 조회 |
+| `POST` | `/api/products` | `ADMIN` | 상품 등록 |
+| `PATCH` | `/api/products/{productId}/price` | `ADMIN` | 가격 수정 |
+| `POST` | `/api/orders/queue` | 사용자 | 대기열 등록, `dev/test/local` 전용 |
+| `POST` | `/api/orders` | 사용자 + 대기열 | `Idempotency-Key` 기반 주문 생성 |
+| `GET` | `/api/orders` | 사용자 | 내 주문 목록 조회 |
+| `PATCH` | `/api/orders/{orderId}/cancel` | 주문 소유자 | 주문 취소와 재고 복구 |
 
-### 1. 주문 정합성
-`OrderConcurrencyIntegrationTest`
+공통 응답은 `ApiResponse`, 오류 응답은 `ErrorResponse` 형식을 사용합니다.
 
-- 45명 동시 주문
-- 재고 40개 기준
-- 성공 40건 / 실패 5건 / 남은 재고 0
+## 테스트와 CI
 
-초과 주문은 일부 실패했지만, **재고가 음수로 내려가지 않고 최종 재고가 정확히 0으로 유지**됐습니다.
+| 목적 | 명령 | 외부 서비스 |
+|---|---|---|
+| 빠른 단위·슬라이스 테스트 | `./gradlew unitTest` | 없음 |
+| 단위 테스트 + 실행 JAR 검증 | `./gradlew verifyChange` | 없음 |
+| 통합·동시성 테스트 | `./gradlew integrationTest` | `localhost:6379` Redis |
+| 대량 데이터·깊은 페이지 실험 | `./gradlew stressTest -PallowStressTest` | 로컬 MySQL, 명시적 승인 필요 |
 
-### 2. 조회 가용성
-`OrderAvailabilityIntegrationTest`
+현재 GitHub Actions는 다음을 수행합니다.
 
-- DB 비관적 락
-  - 총 소요 시간: `418ms`
-  - 조회 성공: `0`
-  - 조회 실패: `20`
-- Redis 분산 락
-  - 총 소요 시간: `8766ms`
-  - 조회 성공: `20`
-  - 조회 실패: `0`
+- 모든 push와 PR: 금지 경로 검사, 전체 이력 Gitleaks 검사
+- `main` 대상 PR: `./gradlew clean verifyChange`
+- `main` push: 동일 검증 후 Docker Hub에 `hongjuhwan/eshop-app:latest` 게시
 
-이 테스트는 **Spring AOP(`TestLatencyAspect`)를 활용해 트랜잭션 내부에 150ms의 인위적인 지연을 주입**하여, 실제 트래픽 폭주로 인한 긴 처리 상황을 재현했습니다.  
-DB 비관적 락은 총 처리 시간은 더 짧았지만, 락 대기와 커넥션 점유로 인해 조회 요청이 실패하는 현상을 확인했습니다.  
-반면 Redis 분산 락은 처리 시간은 더 걸렸지만, **조회 요청 20건이 모두 성공해 시스템 가용성을 지키는 방향을 확인했습니다.**
+`integrationTest`는 아직 CI에 연결되지 않았습니다. 테스트 분리 기준, 재현 방법과 기존 실험 결과는 [테스트와 검증](docs/testing.md)을 참고하세요.
 
-### 3. 락 비용 비교
-`OrderConcurrencyIntegrationTest`
+## 배포 구성
 
-- 락 오버헤드 비교
-  - DB 비관적 락: `199ms`
-  - Redis 분산 락: `432ms`
-- 전체 주문 로직 비교
-  - DB 락(단순 차감): `67ms`
-  - Redis 락(전체 주문): `456ms`
+- `Dockerfile`: JDK 21 빌더와 JRE 21 런타임을 분리한 multi-stage 이미지
+- `docker-compose.prod.yml`: Redis와 blue/green 애플리케이션 컨테이너 정의
+- `deploy.sh`: 새 컨테이너 실행, Nginx upstream 전환, 이전 컨테이너 종료
 
-Redis 분산 락은 단일 요청 기준으로는 더 느렸지만, 조회 가용성을 보존하고 병목을 DB 밖으로 분리할 수 있다는 점에서 운영 관점에 더 적합하다고 판단했습니다.
+현재 CI는 Docker 이미지 게시까지만 자동화합니다. `deploy.sh`를 원격 서버에서 실행하는 단계는 GitHub Actions에 연결되어 있지 않습니다.
 
-### 4. 주문 조회 N+1 완화
-`OrderQueryIntegrationTest`
+## 현재 상태와 다음 개선
 
-- 기존 구조: 주문 1회 조회 + 주문별 `OrderItem` 추가 조회 = `1 + N`
-- 개선 구조: 주문별 반복 조회가 발생하던 구조를 배치 조회 중심 구조로 완화했습니다.
-  주문 조회 후 연관 데이터 조회가 IN 절 기반 배치 조회로 전환되어 반복 쿼리 수를 줄였습니다.
+- 완료: 자격 증명 정리와 저장소 이력 정제([#8](https://github.com/juhwanz/eshop-refac/issues/8), [#9](https://github.com/juhwanz/eshop-refac/issues/9))
+- 다음 보안 작업: 운영 설정 fail-fast와 Actuator 접근 정책([#14](https://github.com/juhwanz/eshop-refac/issues/14))
+- 검증 기반: MySQL·Redis Testcontainers 도입 후 CI 통합 테스트 연결([#16](https://github.com/juhwanz/eshop-refac/issues/16), [#15](https://github.com/juhwanz/eshop-refac/issues/15))
+- 스키마: 현재 `local`은 Hibernate `ddl-auto: update`, `prod`는 `validate`입니다. Flyway 정합성은 [#10](https://github.com/juhwanz/eshop-refac/issues/10)에서 개선 예정입니다.
 
-테스트에서는 Fetch Join + 페이징 시 아래 경고가 발생하는 구조도 함께 비교합니다.
+## 상세 문서
 
-```text
-HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory
-```
-
-즉, 이 프로젝트의 선택은 “무조건 Fetch Join”이 아니라, **페이징 안정성을 유지하면서 N+1을 줄이는 Batch Fetch**입니다.
-
-### 5. 캐시 정합성
-`ProductCacheIntegrationTest`
-
-검증 흐름:
-
-- 1차 조회: Cache Miss -> DB 조회 -> Cache Put
-- 가격 수정: ProductService가 캐시 무효화 이벤트를 발행하고, ProductCacheEventListener가 AFTER_COMMIT 시점에 캐시를 제거
-- 2차 조회: Miss -> 최신 DB 값 조회 -> Cache Put
-
-최종 확인 값은 `20000원`이며, 수정 이후에도 **트랜잭션 커밋 이후에만 캐시를 제거하도록 하여, 수정 실패 시 불필요한 캐시 무효화가 발생하지 않도록 했습니다.**
-
-### 6. 깊은 페이지 조회 성능
-`ProductDeepPaginationTest`
-
-- Offset(40만 건 스캔): `33ms`
-- No-Offset(인덱스 기반): `25ms`
-- 첫 페이지(Offset 0): `5ms`
-- 끝 페이지(Offset 40만): `36ms`
-
-또한 로그 기준으로,
-
-- Offset 방식은 `count(...)` 쿼리가 함께 발생
-- No-Offset 방식은 `where id < ?` 기반 조회로 `count()` 없이 동작
-
-즉, **뒤 페이지로 갈수록 느려지는 Offset의 특성과 count 쿼리 비용**을 줄이기 위해 No-Offset + `Slice`를 적용했습니다.
+- [아키텍처 상세](docs/architecture.md) — 주문, 멱등성, 락, 대기열, 캐시, 조회 설계
+- [테스트와 검증](docs/testing.md) — Gradle task, CI 범위, 통합 테스트와 실험 결과
+- [자격 증명 관리와 유출 대응](docs/security/credential-management.md)
+- [ADR 목록과 작성 규칙](docs/adr/README.md)
+- [ADR-0001: 운영 자격 증명 관리](docs/adr/0001-production-credential-management.md)
+- [개선 로드맵 #27](https://github.com/juhwanz/eshop-refac/issues/27)
 
 ## 프로젝트 구조
 
 ```text
-eshop-refact/
-├── src/main/java/com/project/eshop_refact
-│   ├── domain
-│   │   ├── order
-│   │   ├── product
-│   │   ├── queue
-│   │   └── user
-│   └── global
-│       ├── common
-│       ├── config
-│       ├── exception
-│       ├── interceptor
-│       └── security
-├── src/main/resources
-│   ├── application.yaml
-│   ├── application-secret.yaml
-│   └── application-secret.example.yml
-├── src/test/java/com/project/eshop_refact
-│   ├── aop
-│   ├── config
-│   ├── controller
-│   ├── domain
-│   ├── integration
-│   └── service
-├── Dockerfile
-├── docker-compose.yml
-├── docker-compose.prod.yml
-├── deploy.sh
-└── .github/workflows/deploy.yml
+src/main/java/com/project/eshop_refact
+├── domain
+│   ├── order       # 주문, 멱등성, 분산 락
+│   ├── product     # 상품, QueryDSL, 캐시
+│   ├── queue       # 대기열과 스케줄러
+│   └── user        # 사용자와 토큰 생명주기
+└── global
+    ├── common      # 공통 응답
+    ├── config      # JPA, Redis, QueryDSL, ShedLock
+    ├── exception   # 비즈니스 오류 규격
+    ├── interceptor # 주문 대기열 검사
+    └── security    # JWT와 Spring Security
 ```
-
-## 배포
-
-리포지토리에는 운영 배포를 위한 파일도 포함되어 있습니다.
-
-- `Dockerfile`
-  - 멀티 스테이지 빌드
-  - JRE 런타임 이미지 사용
-  - 비루트 사용자(`spring`)로 실행
-- `.github/workflows/deploy.yml`
-  - `main` 브랜치 push 시 Gradle 빌드
-  - Docker Hub 이미지 푸시
-  - 원격 서버 접속 후 `deploy.sh` 실행
-- `deploy.sh` + `docker-compose.prod.yml`
-  - blue/green 컨테이너 교체
-  - Nginx upstream 포트 전환
-  - Redis + 원격 MySQL(RDS 엔드포인트) 기반 실행
-
-## 참고
-
-- 상품 등록/가격 수정 API는 `ADMIN` 권한이 있어야 호출할 수 있습니다.
-- 주문 생성은 JWT 인증만으로 끝나지 않고, 대기열 진입 허용 상태여야 합니다.
-- `/api/orders/queue`는 실제 인프라(API Gateway, Kafka 등) 도입 전, 백엔드 애플리케이션 레벨에서의 **대규모 부하 제어 및 유량 제어 능력을 검증하기 위한 PoC(개념 증명) 목적의 API**입니다.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,145 @@
+# 아키텍처 상세
+
+README에서는 핵심 구조만 빠르게 파악할 수 있도록 요약하고, 이 문서에서 각 설계의 경계와 현재 구현 범위를 설명합니다.
+
+## 설계 목표
+
+E-Shop의 주문 경로는 다음 불변조건을 우선합니다.
+
+1. 재고는 음수가 될 수 없고 실제 재고보다 많이 판매할 수 없다.
+2. Redis 락 대기 중에는 DB 트랜잭션과 커넥션을 점유하지 않는다.
+3. 같은 사용자의 동일 요청은 새 주문을 만들지 않는다.
+4. 실패한 요청은 멱등성 점유 상태를 정리해 안전하게 재시도할 수 있다.
+5. DB 커밋 전에는 상품 캐시를 제거하지 않는다.
+6. 주문 취소 전에는 요청 사용자와 주문 소유자가 같은지 확인한다.
+
+## 주문 생성 흐름
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Security as JwtAuthenticationFilter
+    participant Queue as QueueInterceptor
+    participant Idempotency as OrderIdempotencyService
+    participant Redis
+    participant Facade as RedissonLockStockFacade
+    participant Service as OrderService
+    participant DB as MySQL
+
+    User->>Security: POST /api/orders
+    Security->>Queue: 인증 사용자 전달
+    Queue->>Redis: active_user:{userId} 확인
+    alt 활성 토큰 없음
+        Queue-->>User: QUEUE_WAITING
+    else 진입 허용
+        Queue->>Idempotency: userId + Idempotency-Key
+        Idempotency->>Redis: SET NX PROCESSING, TTL 3분
+        alt 이미 처리 중
+            Idempotency-->>User: DUPLICATE_RESOURCE
+        else 완료 응답 존재
+            Idempotency-->>User: 저장된 orderId 반환
+        else 새 요청
+            Idempotency->>Facade: order(...)
+            Facade->>Redis: product:stock:{productId} 락
+            Facade->>Service: 락 획득 후 호출
+            Service->>DB: 재고 차감 + 주문 저장
+            DB-->>Service: 쓰기 결과
+            Service->>Redis: commit 이후 상품 캐시 제거
+            Service-->>Facade: 트랜잭션 완료
+            Facade->>Redis: 락 및 활성 토큰 정리
+            Idempotency->>Redis: 응답 저장, TTL 24시간
+            Idempotency-->>User: 201 Created
+        end
+    end
+```
+
+### 락과 트랜잭션 경계
+
+`RedissonLockStockFacade`가 상품 ID 기반 락을 먼저 획득한 뒤 `OrderService.order()`를 호출합니다. DB 트랜잭션은 서비스 메서드에 있으므로 락을 기다리는 동안 HikariCP 커넥션을 점유하지 않습니다.
+
+- 락 키: `product:stock:{productId}`
+- 최대 대기 시간: 기본 10초
+- 고정 lease: 기본 3초
+- 해제 조건: 실제 획득했고 현재 스레드가 소유한 경우
+- 인터럽트: `Thread.currentThread().interrupt()`로 상태 복구
+
+고정 lease와 트랜잭션 timeout 정책의 추가 검토는 로드맵 [#12](https://github.com/juhwanz/eshop-refac/issues/12)에서 진행합니다.
+
+### 멱등성 상태
+
+```text
+키 없음
+  └─ SET NX 성공 → PROCESSING (3분)
+       ├─ 주문 성공 → {"orderId": ...} (24시간)
+       └─ 주문 실패 → 키 삭제 → 클라이언트 재시도 가능
+
+동일 키 재요청
+  ├─ PROCESSING → 중복 처리 오류
+  └─ 완료 JSON → 기존 응답 반환
+```
+
+키 범위는 `idempotency:order:{userId}:{Idempotency-Key}`입니다. 현재 Redis 기반 구현이며 DB 멱등성 레코드와 장애 복구 정책은 [#13](https://github.com/juhwanz/eshop-refac/issues/13)의 범위입니다.
+
+## 주문 취소
+
+취소 요청은 주문에서 상품 ID를 찾고 같은 상품 락을 획득한 뒤 처리합니다. `OrderService.cancelOrder()`는 주문 소유권을 확인하고, 도메인 메서드 `Order.cancel()`을 통해 상태 변경과 재고 복구를 수행합니다.
+
+재고가 바뀐 상품마다 `ProductCacheEvictEvent`를 발행하며, 실제 캐시 제거는 트랜잭션 커밋 이후에 수행됩니다.
+
+## 대기열
+
+대기열은 두 종류의 Redis 키를 사용합니다.
+
+| 키 | 자료구조 | 역할 |
+|---|---|---|
+| `waiting_queue` | Sorted Set | 등록 시각을 score로 사용한 대기 순서 |
+| `active_user:{userId}` | String, TTL 600초 | 주문 생성 경로 진입 허용 토큰 |
+
+`QueueScheduler`는 1초마다 최대 100명을 활성화합니다. 한 번에 최대 1,000명씩 읽는 chunk와 Redis pipeline을 사용하며, ShedLock으로 다중 인스턴스의 중복 스케줄 실행을 막습니다.
+
+`POST /api/orders/queue`는 `dev`, `test`, `local` 프로필에만 존재하는 PoC 지원 API입니다. 실제 운영 환경의 외부 대기열 시스템을 대신하는 완성형 인터페이스는 아닙니다.
+
+## 캐시 정합성
+
+상품 단건 조회는 `@Cacheable("products")`를 사용합니다. 상품 가격이나 재고가 변경되면 서비스는 캐시를 직접 지우지 않고 이벤트를 발행합니다.
+
+```text
+DB 변경 시도
+  ├─ rollback → 이벤트 listener 실행 안 함 → 기존 캐시 유지
+  └─ commit   → AFTER_COMMIT listener → products 캐시 제거
+```
+
+이 구조는 DB 변경이 실패했는데 캐시만 먼저 사라지는 순서 문제를 피합니다.
+
+## 조회 전략
+
+### 상품 목록
+
+- Offset 방식: `Page<Product>`, 조건 검색과 전체 개수 제공
+- No-Offset 방식: `id < lastProductId`, `id DESC`, `Slice<Product>`
+- `pageSize + 1`건을 조회해 다음 페이지 존재 여부를 판단
+
+No-Offset 커서는 마지막으로 받은 상품 ID입니다. 정렬 방향이 내림차순이므로 다음 요청은 이전 마지막 ID보다 작은 행을 조회합니다.
+
+### 주문 목록
+
+주문은 사용자별 `Page<Order>`로 조회하고 DTO 변환 과정에서 주문 항목을 읽습니다. 컬렉션 fetch join과 pageable을 결합하지 않고 Hibernate `default_batch_fetch_size=100`을 사용해 연관 컬렉션 조회를 IN 절 단위로 묶습니다.
+
+## 인증과 토큰 생명주기
+
+- Access Token과 Refresh Token을 분리하고 토큰 type claim을 확인합니다.
+- Refresh Token은 `RT:{email}`에 14일 TTL로 저장합니다.
+- 재발급 시 저장된 토큰과 비교한 뒤 새 Refresh Token으로 교체합니다.
+- 로그아웃 시 Refresh Token을 제거하고 남은 Access Token 수명만큼 blacklist를 유지합니다.
+- 상품 조회와 인증 진입 API 외의 요청은 기본적으로 인증이 필요합니다.
+- 상품 등록과 가격 수정은 `ADMIN` 역할이 필요합니다.
+
+## 관련 코드
+
+- [OrderIdempotencyService](../src/main/java/com/project/eshop_refact/domain/order/OrderIdempotencyService.java)
+- [RedissonLockStockFacade](../src/main/java/com/project/eshop_refact/domain/order/RedissonLockStockFacade.java)
+- [OrderService](../src/main/java/com/project/eshop_refact/domain/order/OrderService.java)
+- [WaitingQueueService](../src/main/java/com/project/eshop_refact/domain/queue/WaitingQueueService.java)
+- [ProductCacheEventListener](../src/main/java/com/project/eshop_refact/domain/product/ProductCacheEventListener.java)
+- [ProductRepositoryImpl](../src/main/java/com/project/eshop_refact/domain/product/ProductRepositoryImpl.java)
+- [JwtAuthenticationFilter](../src/main/java/com/project/eshop_refact/global/security/JwtAuthenticationFilter.java)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,147 @@
+# 테스트와 검증
+
+이 문서는 로컬 테스트와 GitHub Actions가 실제로 실행하는 범위를 구분하고, 기존 성능·동시성 실험 결과를 재현할 때 필요한 조건을 설명합니다.
+
+## Gradle 테스트 분리
+
+| Gradle task | 포함 범위 | 필요한 인프라 | 기본 실행 여부 |
+|---|---|---|---|
+| `test`, `unitTest` | 도메인, 서비스, MVC slice, JWT 단위 테스트 | 없음 | 기본 |
+| `verifyChange` | `unitTest` + `bootJar` | 없음 | CI |
+| `integrationTest` | Spring Context, 캐시, 동시성, 조회 통합 테스트 | H2 + localhost Redis | 별도 |
+| `stressTest` | 대량 데이터와 깊은 페이지 실험 | local 프로필 MySQL | 명시적 승인 필요 |
+
+`test`와 `unitTest`에서는 다음 항목을 제외합니다.
+
+- `integration/**`
+- `stressTest/**`
+- `EshopRefactApplicationTests`
+- `OrderIdempotencyTest`
+
+`ProductDeepPaginationTest`는 개발자 MySQL에 많은 데이터를 만들 수 있어 `integrationTest`에서도 제외하고 `stressTest`에 포함합니다.
+
+## 권장 실행 순서
+
+### 빠른 검증
+
+```bash
+./gradlew unitTest
+```
+
+실행 가능한 JAR까지 함께 확인하려면:
+
+```bash
+./gradlew verifyChange
+```
+
+### Redis 통합 테스트
+
+```bash
+docker compose up -d redis
+./gradlew integrationTest
+```
+
+Redis 연결 실패는 Java 코드 실패와 구분해야 합니다. 통합 테스트 종료 후 개발 중인 Redis를 계속 사용할 필요가 없다면 해당 서비스만 내릴 수 있습니다.
+
+```bash
+docker compose stop redis
+```
+
+### 대량 데이터 실험
+
+이 작업은 로컬 MySQL 데이터를 변경할 수 있습니다. 데이터 생성과 장시간 실행을 인지하고 승인한 경우에만 실행합니다.
+
+```bash
+./gradlew stressTest -PallowStressTest
+```
+
+## 테스트가 증명하는 것
+
+| 테스트 | 검증 대상 |
+|---|---|
+| `OrderConcurrencyIntegrationTest` | 동시 주문 시 성공/실패 수와 최종 재고, DB 락과 Redis 락 비교 |
+| `OrderAvailabilityIntegrationTest` | 주문 경합 중 조회 요청의 생존 여부 |
+| `OrderIdempotencyTest` | 동일 사용자·동일 키 재요청이 기존 주문 응답을 반환하는지 |
+| `OrderQueryIntegrationTest` | 주문 목록 결과와 batch fetch, fetch join 메모리 페이징 비교 |
+| `ProductCacheIntegrationTest` | Cache Miss → Put → AFTER_COMMIT Evict → 최신 값 재조회 |
+| `ProductRepositoryIntegrationTest` | QueryDSL 조건 검색과 No-Offset 커서 경계 |
+| `ProductDeepPaginationTest` | Offset 깊이에 따른 비용과 No-Offset 비교 |
+
+## 기존 실험 결과
+
+아래 값은 저장소 테스트를 개발 환경에서 실행했을 때 기록한 사례입니다. 고정된 CI benchmark가 아니므로 하드웨어, 데이터 분포, JVM warm-up과 실행 시점에 따라 절대값이 달라질 수 있습니다.
+
+### 재고 정합성
+
+- 초기 재고: 40개
+- 동시 주문: 45건
+- 성공: 40건
+- 실패: 5건
+- 최종 재고: 0개
+
+핵심 판정은 처리 시간보다 성공 수와 최종 재고가 초기 재고를 위반하지 않는지입니다.
+
+### 주문 경합 중 조회 가용성
+
+| 방식 | 관찰된 총 소요 시간 | 조회 성공 | 조회 실패 |
+|---|---:|---:|---:|
+| DB 비관적 락 | 418ms | 0 | 20 |
+| Redis 분산 락 | 8,766ms | 20 | 0 |
+
+테스트는 AOP로 트랜잭션 내부 지연을 주입해 커넥션 풀이 작은 상황을 재현합니다. 이 결과는 Redis 방식이 무조건 빠르다는 뜻이 아니라, 락 대기를 DB 밖으로 옮겼을 때 조회 커넥션을 보존할 수 있음을 보여줍니다.
+
+### 락 비용 비교 사례
+
+| 비교 | DB 비관적 락 | Redis 분산 락 |
+|---|---:|---:|
+| 순수 락 오버헤드 | 199ms | 432ms |
+| 전체 주문 흐름 | 67ms | 456ms |
+
+서로 수행 범위가 완전히 같은 운영 benchmark는 아닙니다. 성능 결론은 동일 workload와 MySQL 실행 계획을 수집하는 [#17](https://github.com/juhwanz/eshop-refac/issues/17), [#18](https://github.com/juhwanz/eshop-refac/issues/18), [#25](https://github.com/juhwanz/eshop-refac/issues/25)에서 보강할 예정입니다.
+
+### 깊은 페이지 조회 사례
+
+| 조회 | 관찰 시간 |
+|---|---:|
+| Offset 첫 페이지 | 5ms |
+| Offset 40만 번째 구간 | 36ms |
+| Offset 40만 건 스캔 비교 | 33ms |
+| No-Offset 인덱스 비교 | 25ms |
+
+Offset 검색은 전체 개수를 위한 count query를 사용할 수 있고, No-Offset 검색은 `id < lastProductId`와 `Slice`로 count query 없이 다음 구간을 조회합니다.
+
+## GitHub Actions
+
+### Secret Scan
+
+`.github/workflows/secret-scan.yml`은 모든 push, pull request와 수동 실행에서 동작합니다.
+
+- `repository-hygiene`: `mysql-data/`, binlog, 인증서와 private key 확장자의 Git 추적 차단
+- `gitleaks`: 전체 Git 이력의 비밀정보 패턴 검사
+
+### Build and Publish Image
+
+`.github/workflows/deploy.yml`은 `main` 대상 PR과 `main` push에서 동작합니다.
+
+```text
+checkout
+  → JDK 21
+  → ./gradlew clean verifyChange
+  → main push일 때만 Docker Hub 로그인과 이미지 게시
+```
+
+현재 주의점:
+
+- `verifyChange`는 `integrationTest`를 포함하지 않습니다.
+- workflow가 Redis 서비스를 시작하지만 현재 실행 task에서는 Redis를 사용하지 않습니다.
+- Docker 이미지 게시는 자동이지만 원격 서버의 `deploy.sh` 실행은 자동화되어 있지 않습니다.
+- Testcontainers 기반 통합 테스트와 CI 연결은 [#16](https://github.com/juhwanz/eshop-refac/issues/16), [#15](https://github.com/juhwanz/eshop-refac/issues/15)에서 진행할 예정입니다.
+
+## 변경 완료 전 확인
+
+```bash
+git diff --check
+git status --short
+```
+
+Java, Gradle, 설정 또는 Flyway 변경은 가까운 테스트부터 실행하고 위험도에 따라 `unitTest`, `verifyChange`, `integrationTest` 순으로 범위를 넓힙니다.


### PR DESCRIPTION
## 변경 사항
- README를 프로젝트 개요, 핵심 설계, 빠른 시작, API, CI와 현재 개선 상태 중심으로 재구성
- 긴 주문·락·멱등성·대기열·캐시 설명을 `docs/architecture.md`로 분리
- 테스트 task, CI 실행 범위와 기존 실험 결과를 `docs/testing.md`로 분리
- 현재 CI가 통합 테스트와 원격 서버 배포를 수행하지 않는다는 경계를 명확히 기록
- #8, #9 완료와 #14, #16, #15 등 다음 개선 순서를 현재 로드맵에 맞춰 반영

## 검증
- `git diff --check` 통과
- 저장소 위생 검사 통과
- Markdown 상대 링크 대상 검사 통과
- 문서만 변경하여 로컬 Gradle 테스트는 실행하지 않음

Refs #26
Refs #27