### PR TITLE
[P0] 운영 보안 설정 fail-fast 및 Actuator 접근 정책 검증

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ set +a
 ```
 
 - Swagger UI: <http://localhost:8080/swagger-ui.html>
-- Health endpoint: <http://localhost:8080/actuator/health> (현재 정책상 JWT 인증 필요)
+- Health endpoint: <http://localhost:8080/actuator/health> (인증 없이 상태만 공개, 상세 정보 비공개)
 
 로컬 Compose의 `mysql-data/`는 개발자 런타임 데이터이며 Git에서 추적하지 않습니다. 자격 증명 원칙과 유출 대응은 [보안 문서](docs/security/credential-management.md)를 참고하세요.
 
@@ -163,6 +163,8 @@ set +a
 - `deploy.sh`: 새 컨테이너 실행, Nginx upstream 전환, 이전 컨테이너 종료
 
 현재 CI는 Docker 이미지 게시까지만 자동화합니다. `deploy.sh`를 원격 서버에서 실행하는 단계는 GitHub Actions에 연결되어 있지 않습니다.
+
+운영 프로필은 `DB_PASSWORD`와 `JWT_SECRET_KEY`가 비어 있으면 기동에 실패합니다. Actuator는 `/actuator/health`만 노출하며, 그 외 운영 endpoint는 외부 요청을 차단합니다.
 
 ## 현재 상태와 다음 개선
 

--- a/docs/security/credential-management.md
+++ b/docs/security/credential-management.md
@@ -26,6 +26,13 @@
 - EC2의 `.env`는 배포 사용자만 읽을 수 있도록 권한을 제한한다.
 - Docker Hub access token과 EC2 SSH key는 GitHub Actions secret으로 관리한다.
 - 자격 증명을 교체할 때는 새 값 배포와 상태 확인을 마친 뒤 기존 값을 폐기한다.
+- `prod` 프로필은 `DB_PASSWORD`와 `JWT_SECRET_KEY`가 없거나 공백이면 명확한 오류와 함께 기동을 중단한다.
+
+## 운영 endpoint
+
+- 외부에는 `/actuator/health`만 공개하고 응답의 상세 구성 요소는 숨긴다.
+- `/actuator/metrics`를 포함한 나머지 Actuator endpoint는 노출하지 않고 Spring Security에서도 차단한다.
+- 운영 모니터링을 확장할 때는 endpoint를 공개하기 전에 별도의 인증 또는 내부망 접근 정책을 먼저 적용한다.
 
 ## JWT 서명키 교체
 

--- a/src/main/java/com/project/eshop_refact/global/config/ProductionSecretsValidator.java
+++ b/src/main/java/com/project/eshop_refact/global/config/ProductionSecretsValidator.java
@@ -1,0 +1,30 @@
+package com.project.eshop_refact.global.config;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+/**
+ * 운영 프로필이 필수 자격 증명 없이 시작되는 것을 방지합니다.
+ */
+@Component
+@Profile("prod")
+public class ProductionSecretsValidator {
+
+    private static final List<String> REQUIRED_SECRET_NAMES = List.of("DB_PASSWORD", "JWT_SECRET_KEY");
+
+    public ProductionSecretsValidator(Environment environment) {
+        List<String> missingSecrets = REQUIRED_SECRET_NAMES.stream()
+                .filter(name -> !StringUtils.hasText(environment.getProperty(name)))
+                .toList();
+
+        if (!missingSecrets.isEmpty()) {
+            throw new IllegalStateException(
+                    "Missing required production environment variables: " + String.join(", ", missingSecrets)
+            );
+        }
+    }
+}

--- a/src/main/java/com/project/eshop_refact/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/eshop_refact/global/security/JwtAuthenticationFilter.java
@@ -16,8 +16,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Arrays;
-
 /**
  * JWT 기반 커스텀 인증 필터
  * HTTP 요청의 Authorization 헤더에서 JWT를 추출하여 유효성, 토큰 타입,
@@ -36,9 +34,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request){
-        String[] excludePath = {"/api/users/signup", "/api/users/login", "/api/users/reissue", "/v3/api-docs", "/swagger-ui", "/actuator"};
         String path = request.getRequestURI();
-        return Arrays.stream(excludePath).anyMatch(path::startsWith);
+        return path.equals("/api/users/signup")
+                || path.equals("/api/users/login")
+                || path.equals("/api/users/reissue")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/swagger-ui")
+                || path.equals("/actuator/health")
+                || path.startsWith("/actuator/health/");
     }
 
     @Override

--- a/src/main/java/com/project/eshop_refact/global/security/SecurityConfig.java
+++ b/src/main/java/com/project/eshop_refact/global/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
      * HTTP 요청에 대한 핵심 보안 필터 체인 구성
      * - 세션 관리: JWT 기반 인증을 위해 세션을 사용하지 않는 Stateless 정책 적용
      * - 예외 처리: REST API 환경에 맞춘 커스텀 인증/인가 예외 핸들러 등록
-     * - 인가 정책: 인증/조회 API, 모니터링, 문서화 엔드포인트는 개방하고 상태 변경(POST, PATCH)은 권한 분리
+     * - 인가 정책: 공개 health 확인, 인증/조회 API, 문서화 엔드포인트와 상태 변경(POST, PATCH)의 권한 분리
      */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
@@ -50,6 +50,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/signup", "/api/users/login", "/api/users/reissue").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
+                        .requestMatchers("/actuator/**").denyAll()
                         .requestMatchers("/api/orders/queue").authenticated()// 테스트 전용 허용 명시
                         //.requestMatchers(HttpMethod.POST, "/api/products").permitAll() // 테스트 시에만 사용
                         .requestMatchers(HttpMethod.POST, "/api/products").hasRole("ADMIN")

--- a/src/test/java/com/project/eshop_refact/config/ActuatorSecurityTest.java
+++ b/src/test/java/com/project/eshop_refact/config/ActuatorSecurityTest.java
@@ -1,0 +1,84 @@
+package com.project.eshop_refact.config;
+
+import com.project.eshop_refact.domain.queue.WaitingQueueService;
+import com.project.eshop_refact.global.security.JwtUtil;
+import com.project.eshop_refact.global.security.RestAccessDeniedHandler;
+import com.project.eshop_refact.global.security.RestAuthenticationEntryPoint;
+import com.project.eshop_refact.global.security.SecurityConfig;
+import com.project.eshop_refact.global.security.UserDetailsServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ActuatorSecurityTest.TestActuatorController.class)
+@Import({
+        SecurityConfig.class,
+        RestAuthenticationEntryPoint.class,
+        RestAccessDeniedHandler.class,
+        ActuatorSecurityTest.TestActuatorController.class
+})
+class ActuatorSecurityTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    JwtUtil jwtUtil;
+
+    @MockBean
+    UserDetailsServiceImpl userDetailsServiceImpl;
+
+    @MockBean
+    RedisTemplate<String, String> redisTemplate;
+
+    @MockBean
+    WaitingQueueService waitingQueueService;
+
+    @Test
+    void healthIsPublicWithoutDetails() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.components").doesNotExist());
+    }
+
+    @Test
+    void otherActuatorEndpointsRejectAnonymousRequests() throws Exception {
+        mockMvc.perform(get("/actuator/metrics"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    void otherActuatorEndpointsRejectAuthenticatedExternalRequests() throws Exception {
+        mockMvc.perform(get("/actuator/metrics"))
+                .andExpect(status().isForbidden());
+    }
+
+    @RestController
+    static class TestActuatorController {
+
+        @GetMapping("/actuator/health")
+        Map<String, String> health() {
+            return Map.of("status", "UP");
+        }
+
+        @GetMapping("/actuator/metrics")
+        Map<String, String> metrics() {
+            return Map.of("metric", "sensitive-value");
+        }
+    }
+}

--- a/src/test/java/com/project/eshop_refact/config/ProductionSecretsValidatorTest.java
+++ b/src/test/java/com/project/eshop_refact/config/ProductionSecretsValidatorTest.java
@@ -1,0 +1,50 @@
+package com.project.eshop_refact.config;
+
+import com.project.eshop_refact.global.config.ProductionSecretsValidator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductionSecretsValidatorTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(ProductionSecretsValidator.class);
+
+    @Test
+    void prodProfileFailsToStartWhenRequiredSecretsAreMissing() {
+        contextRunner
+                .withPropertyValues("spring.profiles.active=prod")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasRootCauseInstanceOf(IllegalStateException.class)
+                            .rootCause()
+                            .hasMessage("Missing required production environment variables: DB_PASSWORD, JWT_SECRET_KEY");
+                });
+    }
+
+    @Test
+    void prodProfileStartsWhenRequiredSecretsAreProvided() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.profiles.active=prod",
+                        "DB_PASSWORD=test-db-password",
+                        "JWT_SECRET_KEY=test-jwt-secret"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(ProductionSecretsValidator.class);
+                });
+    }
+
+    @Test
+    void nonProdProfileDoesNotRequireProductionSecrets() {
+        contextRunner
+                .withPropertyValues("spring.profiles.active=local")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).doesNotHaveBean(ProductionSecretsValidator.class);
+                });
+    }
+}

--- a/src/test/java/com/project/eshop_refact/config/ProductionSecurityConfigurationTest.java
+++ b/src/test/java/com/project/eshop_refact/config/ProductionSecurityConfigurationTest.java
@@ -1,0 +1,39 @@
+package com.project.eshop_refact.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductionSecurityConfigurationTest {
+
+    @Test
+    void applicationConfigurationRequiresSecretsAndOnlyExposesHealthWithoutDetails() {
+        YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
+        yaml.setResources(new FileSystemResource("src/main/resources/application.yaml"));
+        Properties properties = yaml.getObject();
+
+        assertThat(properties).isNotNull();
+        assertThat(properties.getProperty("spring.datasource.password")).isEqualTo("${DB_PASSWORD}");
+        assertThat(properties.getProperty("jwt.secret")).isEqualTo("${JWT_SECRET_KEY}");
+        assertThat(properties.getProperty("management.endpoints.web.exposure.include")).isEqualTo("health");
+        assertThat(properties.getProperty("management.endpoint.health.show-details")).isEqualTo("never");
+    }
+
+    @Test
+    void productionComposeRejectsMissingSecretsWithoutFallbacks() throws IOException {
+        String compose = Files.readString(Path.of("docker-compose.prod.yml"));
+
+        assertThat(compose)
+                .contains("${DB_PASSWORD:?DB_PASSWORD is required}")
+                .contains("${JWT_SECRET_KEY:?JWT_SECRET_KEY is required}")
+                .doesNotContain("${DB_PASSWORD:-")
+                .doesNotContain("${JWT_SECRET_KEY:-");
+    }
+}


### PR DESCRIPTION
## 변경 사항
- prod 프로필에서 DB_PASSWORD/JWT_SECRET_KEY 누락 또는 공백 시 명확한 오류로 기동을 중단합니다.
- 인증 없이 /actuator/health만 허용하고 나머지 Actuator 경로는 외부 요청을 차단합니다.
- health-only 노출, 상세 정보 비공개, 운영 Compose의 secret 필수 표기를 CI 테스트로 고정합니다.
- README와 자격 증명 운영 문서를 실제 정책에 맞게 갱신합니다.

## 검증
- ./gradlew test --tests com.project.eshop_refact.config.ProductionSecretsValidatorTest --tests com.project.eshop_refact.config.ActuatorSecurityTest --tests com.project.eshop_refact.config.ProductionSecurityConfigurationTest
- ./gradlew verifyChange
- git diff --check
- ./scripts/check-repository-hygiene.sh

Closes #14