### PR TITLE
build: 로컬 MariaDB와 Redis 개발 환경 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,10 @@
 # Database connection settings
 RDS_HOST=your_rds_endpoint.ap-northeast-2.rds.amazonaws.com
+# Required only when running the full docker-compose.yml MariaDB service
 DB_ROOT_PASSWORD=your_local_mariadb_root_password
 DB_USERNAME=eshop
 DB_PASSWORD=your_db_password
-DB_PORT=3307
+DB_PORT=3306
 REDIS_PORT=6380
 
 # JWT secret key (Base64-encoded random value of at least 256 bits)

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ RDS_HOST=your_rds_endpoint.ap-northeast-2.rds.amazonaws.com
 DB_ROOT_PASSWORD=your_local_mariadb_root_password
 DB_USERNAME=eshop
 DB_PASSWORD=your_db_password
-DB_PORT=3306
+DB_PORT=3307
+REDIS_PORT=6380
 
 # JWT secret key (Base64-encoded random value of at least 256 bits)
 JWT_SECRET_KEY=your_base64_encoded_jwt_secret

--- a/README.md
+++ b/README.md
@@ -97,26 +97,24 @@ cp .env.example .env
 DB_ROOT_PASSWORD=change-me-root
 DB_USERNAME=eshop
 DB_PASSWORD=change-me
-DB_PORT=3306
+DB_PORT=3307
+REDIS_PORT=6380
 JWT_SECRET_KEY=base64-encoded-random-key
 ```
 
-### 2. MariaDB와 Redis 실행
+### 2. Docker Desktop 실행
+
+로컬 프로필로 애플리케이션을 실행하면 Spring Boot가 `docker-compose.dev.yml`의 MariaDB와 Redis를 자동으로 시작합니다. 애플리케이션을 종료하면 두 컨테이너도 함께 중지되며 MariaDB 데이터는 named volume에 보존됩니다.
+
+기본 개발 포트는 기존 로컬 서비스와의 충돌을 피하도록 MariaDB 3307, Redis 6380을 사용합니다. 다른 서비스가 해당 포트를 사용 중이면 `.env`의 `DB_PORT`, `REDIS_PORT`를 변경할 수 있습니다.
+
+### 3. 애플리케이션 실행
 
 ```bash
-docker compose up -d mariadb redis
-```
-
-호스트의 3306 포트를 이미 사용 중이면 `.env`의 `DB_PORT`를 다른 값으로 변경할 수 있습니다. 컨테이너 간 통신은 항상 MariaDB의 3306 포트를 사용합니다.
-
-### 3. 환경변수 로드 후 애플리케이션 실행
-
-```bash
-set -a
-source .env
-set +a
 ./gradlew bootRun --args='--spring.profiles.active=local'
 ```
+
+`.env`는 애플리케이션과 Docker Compose가 자동으로 읽습니다. Docker Desktop은 실행 중이어야 합니다.
 
 - Swagger UI: <http://localhost:8080/swagger-ui.html>
 - Health endpoint: <http://localhost:8080/actuator/health> (인증 없이 상태만 공개, 상세 정보 비공개)

--- a/README.md
+++ b/README.md
@@ -94,32 +94,48 @@ cp .env.example .env
 `.env`에 로컬 환경 값을 설정합니다. 실제 비밀값은 Git에 추가하지 않습니다.
 
 ```dotenv
-DB_ROOT_PASSWORD=change-me-root
 DB_USERNAME=eshop
 DB_PASSWORD=change-me
-DB_PORT=3307
+DB_PORT=3306
 REDIS_PORT=6380
 JWT_SECRET_KEY=base64-encoded-random-key
 ```
 
-### 2. Docker Desktop 실행
+### 2. 로컬 MariaDB 준비
 
-로컬 프로필로 애플리케이션을 실행하면 Spring Boot가 `docker-compose.dev.yml`의 MariaDB와 Redis를 자동으로 시작합니다. 애플리케이션을 종료하면 두 컨테이너도 함께 중지되며 MariaDB 데이터는 named volume에 보존됩니다.
+최초 한 번 로컬 MariaDB에 application database와 사용자를 준비합니다. SQL의 비밀번호는 `.env`의 `DB_PASSWORD`와 같아야 합니다.
 
-기본 개발 포트는 기존 로컬 서비스와의 충돌을 피하도록 MariaDB 3307, Redis 6380을 사용합니다. 다른 서비스가 해당 포트를 사용 중이면 `.env`의 `DB_PORT`, `REDIS_PORT`를 변경할 수 있습니다.
+```bash
+sudo mariadb
+```
 
-### 3. 애플리케이션 실행
+```sql
+CREATE DATABASE IF NOT EXISTS eshop CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS 'eshop'@'localhost' IDENTIFIED BY 'change-me';
+ALTER USER 'eshop'@'localhost' IDENTIFIED BY 'change-me';
+GRANT ALL PRIVILEGES ON eshop.* TO 'eshop'@'localhost';
+FLUSH PRIVILEGES;
+exit;
+```
+
+로컬 프로필로 애플리케이션을 실행하면 Hibernate가 필요한 테이블을 생성하거나 갱신합니다.
+
+### 3. Docker Desktop 실행
+
+Spring Boot는 `docker-compose.dev.yml`의 Redis를 자동으로 시작하고 애플리케이션 종료 시 함께 중지합니다. 기본 Redis 포트는 다른 프로젝트와의 충돌을 피하도록 6380을 사용하며, 필요하면 `.env`의 `REDIS_PORT`를 변경할 수 있습니다.
+
+### 4. 애플리케이션 실행
 
 ```bash
 ./gradlew bootRun --args='--spring.profiles.active=local'
 ```
 
-`.env`는 애플리케이션과 Docker Compose가 자동으로 읽습니다. Docker Desktop은 실행 중이어야 합니다.
+`.env`는 애플리케이션과 Docker Compose가 자동으로 읽습니다. Redis 자동 실행을 위해 Docker Desktop은 실행 중이어야 합니다.
 
 - Swagger UI: <http://localhost:8080/swagger-ui.html>
 - Health endpoint: <http://localhost:8080/actuator/health> (인증 없이 상태만 공개, 상세 정보 비공개)
 
-로컬 Compose는 기존 `mysql-data/`를 재사용하지 않고 `mariadb-data` named volume을 사용합니다. 자격 증명 원칙과 유출 대응은 [보안 문서](docs/security/credential-management.md)를 참고하세요.
+로컬 MariaDB 데이터는 기존 MariaDB 저장공간을 사용합니다. 자격 증명 원칙과 유출 대응은 [보안 문서](docs/security/credential-management.md)를 참고하세요.
 
 ## API 요약
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	// 3. Database & Redis
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
 	// [중요] Redisson
 	implementation 'org.redisson:redisson-spring-boot-starter:3.31.0'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,25 +1,4 @@
 services:
-  mariadb:
-    image: mariadb:11.8.6
-    ports:
-      - "127.0.0.1:${DB_PORT:-3307}:3306"
-    environment:
-      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-${DB_PASSWORD:?DB_PASSWORD is required}}
-      MARIADB_DATABASE: eshop
-      MARIADB_USER: ${DB_USERNAME:-eshop}
-      MARIADB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
-      TZ: Asia/Seoul
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-time-zone=+09:00
-    volumes:
-      - mariadb-data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    labels:
-      org.springframework.boot.jdbc.parameters: timezone=Asia/Seoul
-
   redis:
     image: redis:latest
     ports:
@@ -31,6 +10,3 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
-volumes:
-  mariadb-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,36 @@
+services:
+  mariadb:
+    image: mariadb:11.8.6
+    ports:
+      - "127.0.0.1:${DB_PORT:-3307}:3306"
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-${DB_PASSWORD:?DB_PASSWORD is required}}
+      MARIADB_DATABASE: eshop
+      MARIADB_USER: ${DB_USERNAME:-eshop}
+      MARIADB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      TZ: Asia/Seoul
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-time-zone=+09:00
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    labels:
+      org.springframework.boot.jdbc.parameters: timezone=Asia/Seoul
+
+  redis:
+    image: redis:latest
+    ports:
+      - "127.0.0.1:${REDIS_PORT:-6380}:6379"
+    environment:
+      TZ: Asia/Seoul
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  mariadb-data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
     env_file:
       - ./.env
     environment:
-      SPRING_DATASOURCE_URL: "jdbc:mariadb://${RDS_HOST:?RDS_HOST is required}:${DB_PORT:-3306}/eshop?timezone=Asia/Seoul"
+      SPRING_DATASOURCE_URL: "jdbc:mariadb://${RDS_HOST:?RDS_HOST is required}:${DB_PORT:-3306}/eshop"
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME:?DB_USERNAME is required}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
       SPRING_DATA_REDIS_HOST: redis
@@ -38,7 +38,7 @@ services:
     env_file:
       - ./.env
     environment:
-      SPRING_DATASOURCE_URL: "jdbc:mariadb://${RDS_HOST:?RDS_HOST is required}:${DB_PORT:-3306}/eshop?timezone=Asia/Seoul"
+      SPRING_DATASOURCE_URL: "jdbc:mariadb://${RDS_HOST:?RDS_HOST is required}:${DB_PORT:-3306}/eshop"
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME:?DB_USERNAME is required}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
       SPRING_DATA_REDIS_HOST: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - "8080:8080"
     environment:
       # application.yaml의 설정을 환경 변수로 덮어씌워 내부 컨테이너 통신을 연결합니다.
-      SPRING_DATASOURCE_URL: "jdbc:mariadb://mariadb:3306/eshop?timezone=Asia/Seoul"
+      SPRING_DATASOURCE_URL: "jdbc:mariadb://mariadb:3306/eshop"
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME:-eshop}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
       SPRING_DATA_REDIS_HOST: redis

--- a/docs/adr/0002-use-mariadb-and-hibernate-schema-update.md
+++ b/docs/adr/0002-use-mariadb-and-hibernate-schema-update.md
@@ -16,7 +16,7 @@
 - Flyway 의존성, 설정과 기존 migration 파일을 제거한다.
 - 실제 운영 데이터가 없는 현재 단계에서는 `local`, `prod` 프로필 모두 Hibernate `ddl-auto: update`로 schema를 관리한다.
 - 격리된 H2 테스트는 `MODE=MariaDB`, `ddl-auto: create-drop`을 사용한다.
-- 로컬 개발에서는 Spring Boot Docker Compose 지원과 개발 전용 Compose 파일로 MariaDB와 Redis를 애플리케이션 생명주기에 맞춰 시작·중지한다.
+- 로컬 개발에서는 기존 호스트 MariaDB를 사용하고, Spring Boot Docker Compose 지원으로 Redis만 애플리케이션 생명주기에 맞춰 시작·중지한다.
 - 기존 MySQL 데이터 디렉터리는 MariaDB 데이터 영역으로 재사용하거나 자동 삭제하지 않는다.
 - 실제 운영 데이터가 생기거나 여러 환경의 schema version 관리가 필요해지면 Flyway 같은 migration 도구와 `ddl-auto: validate` 전환을 다시 결정한다.
 
@@ -29,7 +29,7 @@
 ## 결과
 
 - 엔티티 변경을 빈 MariaDB에 빠르게 반영할 수 있고 datasource 및 배포 설정이 단순해진다.
-- 개발 인프라는 애플리케이션 실행 시 준비되고 종료 시 중지되며 MariaDB 데이터는 named volume에 보존된다.
+- 로컬 MariaDB 데이터를 기존 관리 방식으로 확인할 수 있고 Redis 컨테이너는 애플리케이션 실행 시간에만 동작한다.
 - 기존 MySQL 데이터의 이관과 Flyway 이력 보존은 지원하지 않는다.
 - `ddl-auto: update`는 파괴적 변경, rollback, 배포 간 순서 제어를 보장하지 않으므로 실제 데이터가 생긴 뒤에는 사용할 수 없다.
 - blue/green 인스턴스가 동시에 schema를 변경하지 않도록 schema 변경 배포 시 기동 순서를 관리해야 한다.

--- a/docs/adr/0002-use-mariadb-and-hibernate-schema-update.md
+++ b/docs/adr/0002-use-mariadb-and-hibernate-schema-update.md
@@ -16,6 +16,7 @@
 - Flyway 의존성, 설정과 기존 migration 파일을 제거한다.
 - 실제 운영 데이터가 없는 현재 단계에서는 `local`, `prod` 프로필 모두 Hibernate `ddl-auto: update`로 schema를 관리한다.
 - 격리된 H2 테스트는 `MODE=MariaDB`, `ddl-auto: create-drop`을 사용한다.
+- 로컬 개발에서는 Spring Boot Docker Compose 지원과 개발 전용 Compose 파일로 MariaDB와 Redis를 애플리케이션 생명주기에 맞춰 시작·중지한다.
 - 기존 MySQL 데이터 디렉터리는 MariaDB 데이터 영역으로 재사용하거나 자동 삭제하지 않는다.
 - 실제 운영 데이터가 생기거나 여러 환경의 schema version 관리가 필요해지면 Flyway 같은 migration 도구와 `ddl-auto: validate` 전환을 다시 결정한다.
 
@@ -28,6 +29,7 @@
 ## 결과
 
 - 엔티티 변경을 빈 MariaDB에 빠르게 반영할 수 있고 datasource 및 배포 설정이 단순해진다.
+- 개발 인프라는 애플리케이션 실행 시 준비되고 종료 시 중지되며 MariaDB 데이터는 named volume에 보존된다.
 - 기존 MySQL 데이터의 이관과 Flyway 이력 보존은 지원하지 않는다.
 - `ddl-auto: update`는 파괴적 변경, rollback, 배포 간 순서 제어를 보장하지 않으므로 실제 데이터가 생긴 뒤에는 사용할 수 없다.
 - blue/green 인스턴스가 동시에 schema를 변경하지 않도록 schema 변경 배포 시 기동 순서를 관리해야 한다.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 
 # 1. Common Settings
 spring:
+  config:
+    import: optional:file:.env[.properties]
   profiles:
     active: local
   application:
@@ -59,6 +61,10 @@ spring:
   config:
     activate:
       on-profile: local
+  docker:
+    compose:
+      file: docker-compose.dev.yml
+      lifecycle-management: start-and-stop
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ spring:
       connection-timeout: 1000
       # DB의 wait_timeout보다 짧게 설정하여 예기치 않은 커넥션 끊김(Connection Closed) 방지
       max-lifetime: 1800000
-    url: "jdbc:mariadb://localhost:${DB_PORT:3306}/eshop?timezone=Asia/Seoul"
+    url: "jdbc:mariadb://localhost:${DB_PORT:3306}/eshop"
     username: ${DB_USERNAME:eshop}
     password: ${DB_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver


### PR DESCRIPTION
## 변경 사항
- 개발 환경은 기존 호스트 MariaDB 3306을 사용하도록 정리했습니다.
- 개발 전용 docker-compose.dev.yml에는 Redis만 두었습니다.
- Spring Boot 실행 시 Redis를 자동 시작하고 앱 종료 시 자동 중지합니다.
- 다른 프로젝트와 충돌하지 않도록 Redis 기본 호스트 포트는 6380입니다.
- .env를 애플리케이션과 Docker Compose가 자동으로 읽도록 구성했습니다.
- 로컬 MariaDB의 eshop database와 계정 준비 절차를 README에 추가하고 ADR-0002를 갱신했습니다.
- 로컬 MariaDB에 시간대 이름 테이블이 없어도 접속하도록 JDBC URL의 세션 시간대 강제를 제거했습니다.

## 검증
- ./gradlew unitTest
- ./gradlew verifyChange
- 개발용 및 기존 Compose config 검사
- .env 자격 증명으로 로컬 MariaDB eshop 접속 확인
- 앱 실행 시 Redis 6380 자동 시작 및 healthcheck 통과 확인
- Hibernate의 users, products, orders, order_item 생성 확인
- 애플리케이션 health UP 확인
- 앱 종료 시 Redis 자동 중지 확인
- 저장소 위생 및 git diff --check

## 로컬 환경 상태
- 이전 검증용 Docker MariaDB 컨테이너와 volume을 제거했습니다.
- 기존 호스트 MariaDB에 eshop schema가 생성됐습니다.
- Redis 컨테이너는 정상 중지 상태입니다.

## 참고
- PR #34 병합 직후 요청된 후속 개발 환경 변경입니다.

Related to #33
Follow-up to #34