### PR TITLE
test: MariaDB·Redis Testcontainers 통합 테스트 환경 구축

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## 목적
 
 - 이 파일은 이 저장소에서 AI와 페어 프로그래밍할 때 지켜야 할 작업 원칙을 정의한다.
-- 사용자를 최종 의사결정권자로 대한다. 중요한 선택에는 근거와 장단점을 설명하고, 범위가 분명한 요청은 스스로 구현하고 검증한다.
+- 사용자를 최종 의사결정권자로 대한다. 중요한 선택에는 근거와 장단점을 설명하고, 명시적으로 구현을 요청받았으며 범위가 분명한 작업은 스스로 구현하고 검증한다.
 - 별도 요청이 없으면 진행 상황, 발견 사항, 최종 결과를 한국어로 전달한다.
 - 기존 아키텍처와 비즈니스 불변조건을 보존하는 작고 검토 가능한 변경을 우선한다.
 
@@ -12,17 +12,16 @@
 - Java 21, Spring Boot, Gradle 기반의 단일 모듈 이커머스 백엔드다.
 - 기본 패키지는 `com.project.eshop_refact`다.
 - 핵심 관심사는 재고 정합성, 주문 멱등성, 동시성 제어, 조회 가용성, 캐시 정합성, 깊은 페이지 조회 성능이다.
-- 운영형 데이터베이스는 MySQL이며 Redis는 캐시, 분산 락, 멱등성, 대기열, ShedLock에 사용한다.
-- JPA/Hibernate, QueryDSL, Flyway, Spring Security, JWT, Actuator, SpringDoc을 사용한다.
+- 현재 데이터베이스는 MariaDB이며 Redis는 캐시, 분산 락, 멱등성, 대기열, ShedLock에 사용한다.
+- JPA/Hibernate, QueryDSL, Spring Security, JWT, Actuator, SpringDoc을 사용한다.
 
 ## 저장소 구조
 
 - `src/main/java/com/project/eshop_refact/domain`: 주문, 상품, 사용자, 대기열 도메인 코드
 - `src/main/java/com/project/eshop_refact/global`: 공통 설정, 보안, 예외, 인터셉터, 응답 타입
-- `src/main/resources/db/migration`: 버전이 부여된 Flyway 마이그레이션
 - `src/test/java/.../controller`: Spring MVC 슬라이스 테스트
 - `src/test/java/.../service`, `.../domain`: 서비스 단위 테스트와 도메인 테스트
-- `src/test/java/.../integration`: H2와 Redis를 사용하는 통합·동시성 테스트
+- `src/test/java/.../integration`: Testcontainers의 MariaDB와 Redis를 사용하는 통합·동시성 테스트
 - `src/test/java/.../stressTest`: 로컬 데이터 및 부하 테스트 준비 도구이며 일반 단위 테스트가 아님
 
 ## 페어 프로그래밍 절차
@@ -30,10 +29,19 @@
 1. 수정 전에 관련 운영 코드, 테스트, 설정과 `git status`를 확인한다.
 2. 요구사항이 모호하면 가정을 밝힌다. 저장소에서 안전하게 추론 가능한 사소한 사항 때문에 작업을 멈추지 않는다.
 3. 버그 수정은 원인을 먼저 규명하고 가능하면 회귀 테스트를 추가하거나 보완한다.
-4. 요청을 해결하는 가장 작은 단위의 일관된 변경을 구현한다.
+4. 명시적으로 구현을 승인받은 뒤 요청을 해결하는 가장 작은 단위의 일관된 변경을 구현한다.
 5. 변경 지점과 가장 가까운 테스트부터 실행하고 위험도에 따라 검증 범위를 넓힌다.
 6. 최종 diff에서 무관한 수정, 비밀정보, 생성 파일, 런타임 데이터가 섞이지 않았는지 확인한다.
 7. 변경 동작, 수행한 검증, 실패하거나 생략한 검사, 남은 위험을 보고한다.
+
+## 이슈 기반 작업 절차
+
+- 이슈 번호를 전달받거나 이슈 작업을 요청받으면 먼저 이슈 본문, 관련 이슈와 ADR, 현재 코드와 테스트를 확인한다.
+- 확인 후 구현 범위, 접근 방법, 변경 예상 파일, 테스트 계획, 주요 선택과 장단점을 설계안으로 보고한다.
+- 사용자가 설계안을 승인하고 명시적으로 구현을 요청하기 전에는 코드나 설정을 수정하지 않는다.
+- `진행하자`, `처리하자`, `살펴보자`처럼 단계가 불분명한 표현은 구현 승인으로 간주하지 않고 설계까지만 진행한다.
+- `구현해줘`, `수정해줘`, `적용해줘` 또는 설계안에 대한 명시적 구현 승인이 있어야 구현과 검증을 수행한다.
+- 구현 승인은 브랜치 생성, 커밋, 푸시, PR 생성이나 병합을 승인하지 않는다. Git 작업은 각각 사용자가 명시한 범위에서만 수행한다.
 
 ## 변경 원칙
 
@@ -42,7 +50,7 @@
 - 시스템 Gradle 대신 항상 Gradle Wrapper인 `./gradlew`를 사용한다.
 - 운영 의존성 추가가 아키텍처나 운영에 영향을 줄 수 있으면 먼저 필요성과 대안을 설명한다.
 - `build/generated/querydsl` 아래의 QueryDSL 생성 코드를 직접 수정하지 않는다.
-- `mysql-data/` 아래의 런타임 데이터를 수정하거나 Git에 추가하지 않는다.
+- `mysql-data/`, `mariadb-data/`와 Docker named volume의 런타임 데이터를 수정하거나 Git에 추가하지 않는다.
 - `build/`, IDE 메타데이터, `.DS_Store`, `__pycache__/`, 로그, 토큰, 로컬 비밀 설정을 커밋하지 않는다.
 - 이슈 생성이나 구현 요청은 브랜치 생성, 커밋, 푸시, PR 생성을 자동으로 승인하지 않는다. 각 Git 작업은 사용자가 명시적으로 요청한 경우에만 수행한다.
 - Git 작업을 요청받은 경우에도 요청된 범위까지만 진행하고 작업 관련 경로만 포함하며, 수행한 커밋과 대상 브랜치를 보고한다.
@@ -97,13 +105,11 @@
 - 사용자의 승인 없이 ADR을 생성하거나 아직 합의되지 않은 내용을 확정된 결정으로 기록하지 않는다.
 - 사소한 구현 선택이나 코드와 테스트만으로 의도가 충분히 드러나는 변경에는 ADR을 제안하지 않는다.
 
-## 영속성, QueryDSL, Flyway
+## 영속성, QueryDSL, schema 관리
 
-- MySQL 스키마는 Flyway가 관리하고 local/prod 성격의 프로필에서는 Hibernate `ddl-auto`를 `validate`로 유지한다.
-- 스키마 변경은 `V2__add_order_index.sql`처럼 새 마이그레이션으로 추가한다.
-- 이미 적용된 버전 마이그레이션은 수정하지 않고 새 버전으로 전진 적용한다.
-- local 또는 prod 스키마 변경에 `ddl-auto: update`, `create`, `create-drop`을 사용하지 않는다.
-- H2의 `create-drop`은 격리된 테스트 설정에서만 사용한다.
+- 실제 운영 데이터가 없는 현재 단계에서는 MariaDB 스키마를 Hibernate가 관리하고 local/prod 프로필에 `ddl-auto: update`를 사용한다.
+- 실제 운영 데이터가 생기거나 여러 환경의 schema version 관리가 필요해지면 Flyway 같은 migration 도구와 `ddl-auto: validate` 전환을 재검토한다.
+- 통합 테스트는 Testcontainers의 MariaDB에서 `create-drop`을 사용해 테스트 클래스별 schema를 격리한다.
 - 컬렉션 fetch join과 pageable을 함께 사용해 메모리 페이징이 발생하지 않도록 한다.
 - No-offset 페이지 조회를 변경할 때 커서 방향, 결정적인 정렬, 경계값, 지원 인덱스를 함께 검증한다.
 - 성능 쿼리를 변경할 때 결과 정합성과 쿼리 수·형태를 모두 확인한다.
@@ -113,7 +119,7 @@
 ### 빠른 검증
 
 - 변경 코드와 가장 가까운 테스트를 먼저 실행한다.
-- 일반적으로 실제 Redis나 MySQL 없이 실행할 수 있는 테스트 묶음은 다음과 같다.
+- 일반적으로 실제 Redis나 MariaDB 없이 실행할 수 있는 테스트 묶음은 다음과 같다.
 
 ```bash
 ./gradlew unitTest
@@ -124,21 +130,20 @@
 
 ### 통합·동시성 테스트
 
-- 전체 Spring Context를 사용하는 테스트는 `localhost:6379`의 Redis가 필요할 수 있다. `local` 프로필이 명시되지 않은 테스트 데이터는 H2를 사용한다.
-- 통합 검증에 Redis가 필요하면 필요한 서비스만 실행한다.
+- 통합 테스트는 Testcontainers가 MariaDB와 Redis를 시작하고 동적 접속 정보를 주입한다.
+- 개발자 로컬 MariaDB와 Redis를 미리 실행하지 않으며 Docker만 준비한다.
 
 ```bash
-docker compose up -d redis
 ./gradlew integrationTest
 ```
 
-- Redis 연결 실패를 Java 또는 애플리케이션 코드 호환성 실패로 설명하지 않는다.
+- 컨테이너 시작 실패를 Java 또는 애플리케이션 코드 호환성 실패로 설명하지 않고 Docker 상태와 이미지 다운로드 가능 여부를 확인한다.
 - 동시성 테스트 실패 시 timeout이나 스레드 수를 바꾸기 전에 락 범위, 트랜잭션 경계, 공유 상태 정리, executor 종료를 조사한다.
 - 테스트를 통과시키기 위해 assertion을 약화하거나 동시성을 낮추거나 임의의 sleep을 추가하지 않는다.
 
 ### 부하 테스트 준비 도구
 
-- `src/test/java/.../stressTest` 아래 클래스는 `local` 프로필로 개발자 MySQL에 많은 데이터를 기록할 수 있다.
+- `src/test/java/.../stressTest` 아래 클래스는 `local` 프로필로 개발자 MariaDB에 많은 데이터를 기록할 수 있다.
 - 사용자가 부하 테스트 준비를 명시적으로 요청하거나 DB 변경을 승인하지 않으면 실행하지 않는다.
 - 스트레스 및 대량 데이터 테스트는 기본 `test`에서 제외되어 있다.
 - 실행 승인을 확인한 뒤에만 `./gradlew stressTest -PallowStressTest`를 사용한다.
@@ -156,7 +161,7 @@ docker compose up -d redis
 
 ## Codex 자동화
 
-- Java, Gradle, 설정, Flyway 변경에는 저장소 Skill인 `eshop-change-verification`을 활용한다.
+- Java, Gradle, 설정, schema 관리 변경에는 저장소 Skill인 `eshop-change-verification`을 활용한다.
 - 구현 후 가까운 테스트를 실행하고, 작업으로 인한 실패면 원인을 수정한 뒤 같은 검증을 다시 실행한다.
 - 외부 서비스 부재, 사용자 데이터 변경 가능성, 요청 범위를 벗어난 실패가 있으면 자동 반복을 멈추고 정확한 상태를 보고한다.
 - 저장소의 `Stop` Hook은 종료 전에 whitespace 오류, 민감 파일 추적, 새 비밀정보 패턴을 검사한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,14 @@
 - Java 21, Spring Boot, Gradle 기반의 단일 모듈 이커머스 백엔드다.
 - 기본 패키지는 `com.project.eshop_refact`다.
 - 핵심 관심사는 재고 정합성, 주문 멱등성, 동시성 제어, 조회 가용성, 캐시 정합성, 깊은 페이지 조회 성능이다.
-- 현재 데이터베이스는 MariaDB이며 Redis는 캐시, 분산 락, 멱등성, 대기열, ShedLock에 사용한다.
-- JPA/Hibernate, QueryDSL, Spring Security, JWT, Actuator, SpringDoc을 사용한다.
+- 운영형 데이터베이스는 MySQL이며 Redis는 캐시, 분산 락, 멱등성, 대기열, ShedLock에 사용한다.
+- JPA/Hibernate, QueryDSL, Flyway, Spring Security, JWT, Actuator, SpringDoc을 사용한다.
 
 ## 저장소 구조
 
 - `src/main/java/com/project/eshop_refact/domain`: 주문, 상품, 사용자, 대기열 도메인 코드
 - `src/main/java/com/project/eshop_refact/global`: 공통 설정, 보안, 예외, 인터셉터, 응답 타입
+- `src/main/resources/db/migration`: 버전이 부여된 Flyway 마이그레이션
 - `src/test/java/.../controller`: Spring MVC 슬라이스 테스트
 - `src/test/java/.../service`, `.../domain`: 서비스 단위 테스트와 도메인 테스트
 - `src/test/java/.../integration`: H2와 Redis를 사용하는 통합·동시성 테스트
@@ -41,9 +42,10 @@
 - 시스템 Gradle 대신 항상 Gradle Wrapper인 `./gradlew`를 사용한다.
 - 운영 의존성 추가가 아키텍처나 운영에 영향을 줄 수 있으면 먼저 필요성과 대안을 설명한다.
 - `build/generated/querydsl` 아래의 QueryDSL 생성 코드를 직접 수정하지 않는다.
-- `mysql-data/`, `mariadb-data/`와 Docker named volume의 런타임 데이터를 수정하거나 Git에 추가하지 않는다.
+- `mysql-data/` 아래의 런타임 데이터를 수정하거나 Git에 추가하지 않는다.
 - `build/`, IDE 메타데이터, `.DS_Store`, `__pycache__/`, 로그, 토큰, 로컬 비밀 설정을 커밋하지 않는다.
-- 사용자가 명시적으로 요청하지 않으면 커밋하거나 푸시하지 않는다. 요청받은 경우에도 작업 관련 경로만 포함하고 커밋과 대상 브랜치를 보고한다.
+- 이슈 생성이나 구현 요청은 브랜치 생성, 커밋, 푸시, PR 생성을 자동으로 승인하지 않는다. 각 Git 작업은 사용자가 명시적으로 요청한 경우에만 수행한다.
+- Git 작업을 요청받은 경우에도 요청된 범위까지만 진행하고 작업 관련 경로만 포함하며, 수행한 커밋과 대상 브랜치를 보고한다.
 
 ## Java와 빌드 설정
 
@@ -95,10 +97,12 @@
 - 사용자의 승인 없이 ADR을 생성하거나 아직 합의되지 않은 내용을 확정된 결정으로 기록하지 않는다.
 - 사소한 구현 선택이나 코드와 테스트만으로 의도가 충분히 드러나는 변경에는 ADR을 제안하지 않는다.
 
-## 영속성, QueryDSL, schema 관리
+## 영속성, QueryDSL, Flyway
 
-- 실제 운영 데이터가 없는 현재 단계에서는 MariaDB 스키마를 Hibernate가 관리하고 local/prod 프로필에 `ddl-auto: update`를 사용한다.
-- 실제 운영 데이터가 생기거나 여러 환경의 schema version 관리가 필요해지면 Flyway 같은 migration 도구와 `ddl-auto: validate` 전환을 재검토한다.
+- MySQL 스키마는 Flyway가 관리하고 local/prod 성격의 프로필에서는 Hibernate `ddl-auto`를 `validate`로 유지한다.
+- 스키마 변경은 `V2__add_order_index.sql`처럼 새 마이그레이션으로 추가한다.
+- 이미 적용된 버전 마이그레이션은 수정하지 않고 새 버전으로 전진 적용한다.
+- local 또는 prod 스키마 변경에 `ddl-auto: update`, `create`, `create-drop`을 사용하지 않는다.
 - H2의 `create-drop`은 격리된 테스트 설정에서만 사용한다.
 - 컬렉션 fetch join과 pageable을 함께 사용해 메모리 페이징이 발생하지 않도록 한다.
 - No-offset 페이지 조회를 변경할 때 커서 방향, 결정적인 정렬, 경계값, 지원 인덱스를 함께 검증한다.
@@ -109,7 +113,7 @@
 ### 빠른 검증
 
 - 변경 코드와 가장 가까운 테스트를 먼저 실행한다.
-- 일반적으로 실제 Redis나 MariaDB 없이 실행할 수 있는 테스트 묶음은 다음과 같다.
+- 일반적으로 실제 Redis나 MySQL 없이 실행할 수 있는 테스트 묶음은 다음과 같다.
 
 ```bash
 ./gradlew unitTest
@@ -134,7 +138,7 @@ docker compose up -d redis
 
 ### 부하 테스트 준비 도구
 
-- `src/test/java/.../stressTest` 아래 클래스는 `local` 프로필로 개발자 MariaDB에 많은 데이터를 기록할 수 있다.
+- `src/test/java/.../stressTest` 아래 클래스는 `local` 프로필로 개발자 MySQL에 많은 데이터를 기록할 수 있다.
 - 사용자가 부하 테스트 준비를 명시적으로 요청하거나 DB 변경을 승인하지 않으면 실행하지 않는다.
 - 스트레스 및 대량 데이터 테스트는 기본 `test`에서 제외되어 있다.
 - 실행 승인을 확인한 뒤에만 `./gradlew stressTest -PallowStressTest`를 사용한다.
@@ -152,7 +156,7 @@ docker compose up -d redis
 
 ## Codex 자동화
 
-- Java, Gradle, 설정, schema 관리 변경에는 저장소 Skill인 `eshop-change-verification`을 활용한다.
+- Java, Gradle, 설정, Flyway 변경에는 저장소 Skill인 `eshop-change-verification`을 활용한다.
 - 구현 후 가까운 테스트를 실행하고, 작업으로 인한 실패면 원인을 수정한 뒤 같은 검증을 다시 실행한다.
 - 외부 서비스 부재, 사용자 데이터 변경 가능성, 요청 범위를 벗어난 실패가 있으면 자동 반복을 멈추고 정확한 상태를 보고한다.
 - 저장소의 `Stop` Hook은 종료 전에 whitespace 오류, 민감 파일 추적, 새 비밀정보 패턴을 검사한다.
@@ -160,8 +164,10 @@ docker compose up -d redis
 
 ## Git과 작업 완료
 
-- 이슈 작업은 최신 `main`에서 분기한 별도 작업 브랜치에서 수행한다. 코드와 문서 변경을 `main`에 직접 커밋하거나 push하지 않는다.
-- 구현과 검증이 끝나면 작업 브랜치를 push하고 `main` 대상 PR을 생성한다. PR 본문에는 관련 이슈를 `Closes #번호` 형식으로 연결한다.
+- 기본 작업 범위는 현재 작업 트리의 코드·문서 수정과 검증까지다.
+- 브랜치 생성, 커밋, 푸시, PR 생성은 사용자가 해당 작업을 명시적으로 요청한 경우에만 수행한다. 여러 Git 작업을 함께 요청받은 경우에만 요청된 범위까지 연속해서 진행한다.
+- 이슈 작업을 위한 브랜치 생성을 요청받으면 최신 `main`에서 별도 작업 브랜치를 만든다. 코드와 문서 변경을 `main`에 직접 커밋하거나 푸시하지 않는다.
+- PR 생성을 요청받으면 작업 브랜치를 푸시하고 `main`을 대상으로 생성한다. PR 본문에는 관련 이슈를 `Closes #번호` 형식으로 연결한다.
 - 필수 CI가 통과하고 PR이 병합되기 전에는 관련 이슈를 수동으로 닫지 않는다. 사용자가 명시적으로 병합을 요청하지 않으면 PR을 임의로 병합하지 않는다.
 - Git 이력 재작성처럼 PR로 처리할 수 없는 예외 작업은 실행 전에 이유, 영향받는 ref, 협업 영향과 복구 방법을 설명하고 사용자의 명시적 승인을 받는다.
 - 커밋 전에 `git diff --check`를 실행하고 작업 관련 diff를 정확히 검토한다.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Spring Boot는 `docker-compose.dev.yml`의 Redis를 자동으로 시작하고 �
 |---|---|---|
 | 빠른 단위·슬라이스 테스트 | `./gradlew unitTest` | 없음 |
 | 단위 테스트 + 실행 JAR 검증 | `./gradlew verifyChange` | 없음 |
-| 통합·동시성 테스트 | `./gradlew integrationTest` | `localhost:6379` Redis |
+| 통합·동시성 테스트 | `./gradlew integrationTest` | Docker(Testcontainers MariaDB·Redis) |
 | 대량 데이터·깊은 페이지 실험 | `./gradlew stressTest -PallowStressTest` | 로컬 MariaDB, 명시적 승인 필요 |
 
 현재 GitHub Actions는 다음을 수행합니다.
@@ -172,7 +172,7 @@ Spring Boot는 `docker-compose.dev.yml`의 Redis를 자동으로 시작하고 �
 - `main` 대상 PR: `./gradlew clean verifyChange`
 - `main` push: 동일 검증 후 Docker Hub에 `hongjuhwan/eshop-app:latest` 게시
 
-`integrationTest`는 아직 CI에 연결되지 않았습니다. 테스트 분리 기준, 재현 방법과 기존 실험 결과는 [테스트와 검증](docs/testing.md)을 참고하세요.
+`integrationTest`는 로컬 DB나 Redis를 미리 실행하지 않아도 되며, 아직 CI에는 연결되지 않았습니다. 테스트 분리 기준, 재현 방법과 기존 실험 결과는 [테스트와 검증](docs/testing.md)을 참고하세요.
 
 ## 배포 구성
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ group = 'com.demo'
 version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
+ext['testcontainers.version'] = '1.21.4'
+
 java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)
@@ -62,6 +64,8 @@ dependencies {
 	// 7. Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mariadb'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 
@@ -106,7 +110,7 @@ tasks.register('unitTest') {
 
 tasks.register('integrationTest', Test) {
 	group = 'verification'
-	description = 'H2와 로컬 Redis를 사용하는 통합·동시성 테스트를 실행합니다.'
+	description = 'Testcontainers의 MariaDB와 Redis를 사용하는 통합·동시성 테스트를 실행합니다.'
 	testClassesDirs = sourceSets.test.output.classesDirs
 	classpath = sourceSets.test.runtimeClasspath
 	useJUnitPlatform()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | `test`, `unitTest` | 도메인, 서비스, MVC slice, JWT 단위 테스트 | 없음 | 기본 |
 | `verifyChange` | `unitTest` + `bootJar` | 없음 | CI |
-| `integrationTest` | Spring Context, 캐시, 동시성, 조회 통합 테스트 | H2 + localhost Redis | 별도 |
+| `integrationTest` | Spring Context, 캐시, 동시성, 조회 통합 테스트 | Docker | 별도 |
 | `stressTest` | 대량 데이터와 깊은 페이지 실험 | local 프로필 MariaDB | 명시적 승인 필요 |
 
 `test`와 `unitTest`에서는 다음 항목을 제외합니다.
@@ -34,18 +34,13 @@
 ./gradlew verifyChange
 ```
 
-### Redis 통합 테스트
+### MariaDB·Redis 통합 테스트
 
 ```bash
-docker compose up -d redis
 ./gradlew integrationTest
 ```
 
-Redis 연결 실패는 Java 코드 실패와 구분해야 합니다. 통합 테스트 종료 후 개발 중인 Redis를 계속 사용할 필요가 없다면 해당 서비스만 내릴 수 있습니다.
-
-```bash
-docker compose stop redis
-```
+Testcontainers가 `mariadb:11.8.6`과 `redis:7.4.5-alpine`을 시작하고 동적 접속 정보를 주입합니다. 개발자 로컬 MariaDB·Redis는 사용하지 않으며 컨테이너는 Gradle 테스트 JVM 안에서 공유하고 실행이 끝나면 폐기합니다. Docker가 꺼져 있거나 이미지를 받을 수 없으면 컨테이너 시작 단계에서 인프라 오류로 실패합니다.
 
 ### 대량 데이터 실험
 
@@ -135,7 +130,7 @@ checkout
 - `verifyChange`는 `integrationTest`를 포함하지 않습니다.
 - workflow가 Redis 서비스를 시작하지만 현재 실행 task에서는 Redis를 사용하지 않습니다.
 - Docker 이미지 게시는 자동이지만 원격 서버의 `deploy.sh` 실행은 자동화되어 있지 않습니다.
-- Testcontainers 기반 통합 테스트와 CI 연결은 [#16](https://github.com/juhwanz/eshop-refac/issues/16), [#15](https://github.com/juhwanz/eshop-refac/issues/15)에서 진행할 예정입니다.
+- Testcontainers 기반 통합 테스트는 [#16](https://github.com/juhwanz/eshop-refac/issues/16), CI 연결은 [#15](https://github.com/juhwanz/eshop-refac/issues/15)에서 추적합니다.
 
 ## 변경 완료 전 확인
 

--- a/src/test/java/com/project/eshop_refact/EshopRefactApplicationTests.java
+++ b/src/test/java/com/project/eshop_refact/EshopRefactApplicationTests.java
@@ -1,10 +1,11 @@
 package com.project.eshop_refact;
 
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class EshopRefactApplicationTests {
+class EshopRefactApplicationTests extends MariaDbRedisIntegrationTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/project/eshop_refact/OrderIdempotencyTest.java
+++ b/src/test/java/com/project/eshop_refact/OrderIdempotencyTest.java
@@ -2,11 +2,14 @@ package com.project.eshop_refact;
 
 import com.project.eshop_refact.domain.order.OrderDto;
 import com.project.eshop_refact.domain.order.OrderIdempotencyService;
+import com.project.eshop_refact.domain.order.OrderRepository;
 import com.project.eshop_refact.domain.product.Product;
 import com.project.eshop_refact.domain.product.ProductRepository;
 import com.project.eshop_refact.domain.user.User;
 import com.project.eshop_refact.domain.user.UserRepository;
 import com.project.eshop_refact.domain.user.UserRoleEnum;
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,18 +27,26 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
  * 중복으로 처리되지 않고 1회만 안전하게 처리됨을 검증합니다.
  */
 @SpringBootTest
-public class OrderIdempotencyTest {
+public class OrderIdempotencyTest extends MariaDbRedisIntegrationTest {
 
     @Autowired
     private OrderIdempotencyService orderIdempotencyService;
     @Autowired private RedisTemplate<String, String> redisTemplate;
     @Autowired private UserRepository userRepository;
     @Autowired private ProductRepository productRepository;
+    @Autowired private OrderRepository orderRepository;
 
     @BeforeEach
     void setup(){
         // 독립적인 테스트 환경 구성을 위한 Redis 초기화
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    @AfterEach
+    void tearDown() {
+        orderRepository.deleteAll();
+        productRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/project/eshop_refact/integration/OrderAvailabilityIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/OrderAvailabilityIntegrationTest.java
@@ -7,14 +7,15 @@ import com.project.eshop_refact.domain.order.RedissonLockStockFacade;
 import com.project.eshop_refact.domain.order.OrderRepository;
 import com.project.eshop_refact.domain.product.ProductRepository;
 import com.project.eshop_refact.domain.user.UserRepository;
-import com.project.eshop_refact.domain.product.ProductService;
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -39,11 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         "app.order.lock.wait-time=30"
 })
 @ActiveProfiles("test")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-public class OrderAvailabilityIntegrationTest {
+public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTest {
 
-    @Autowired
-    private ProductService productService;
     @Autowired
     private RedissonLockStockFacade redissonLockStockFacade;
     @Autowired
@@ -52,6 +50,8 @@ public class OrderAvailabilityIntegrationTest {
     private ProductRepository productRepository;
     @Autowired
     private OrderRepository orderRepository;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
 
     @AfterEach
     void tearDown() {
@@ -67,7 +67,7 @@ public class OrderAvailabilityIntegrationTest {
         // 트랜잭션 내부에서 대기 시간(지연)이 발생하여 커넥션 풀이 빠르게 고갈됩니다.
         // 이로 인해 락과 무관한 '단순 조회' 요청마저 커넥션 타임아웃으로 실패해야 합니다.
         System.out.println("\n========== [1. DB 비관적 락 테스트 시작] ==========");
-        TestResult dbResult = runTest("DB 비관적 락", (id, pid) -> productService.decreaseStock(pid, 1));
+        TestResult dbResult = runTest("DB 비관적 락", (id, pid) -> decreaseStockWhileHoldingConnection(pid));
 
         assertThat(dbResult.remainingStock()).isGreaterThan(50);
         assertThat(dbResult.viewFailCount()).isGreaterThan(0); // 커넥션 고갈에 따른 조회 장애 발생 검증
@@ -85,6 +85,19 @@ public class OrderAvailabilityIntegrationTest {
     }
 
     record TestResult(int remainingStock, int viewFailCount) {
+    }
+
+    private void decreaseStockWhileHoldingConnection(Long productId) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            Product product = productRepository.findByIdWithPessimisticLock(productId).orElseThrow();
+            try {
+                Thread.sleep(150);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("DB connection 점유 시뮬레이션이 중단됐습니다.", exception);
+            }
+            product.removeStock(1);
+        });
     }
 
     private TestResult runTest(String method, StockStrategy strategy) throws InterruptedException {
@@ -130,7 +143,8 @@ public class OrderAvailabilityIntegrationTest {
             });
         }
 
-        latch.await();
+        assertThat(latch.await(2, java.util.concurrent.TimeUnit.MINUTES)).isTrue();
+        executor.shutdownNow();
         long time = System.currentTimeMillis() - start;
 
         Product finalProduct = productRepository.findById(product.getId()).orElseThrow();

--- a/src/test/java/com/project/eshop_refact/integration/OrderConcurrencyIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/OrderConcurrencyIntegrationTest.java
@@ -10,6 +10,7 @@ import com.project.eshop_refact.domain.user.UserRepository;
 import com.project.eshop_refact.domain.order.OrderService;
 import com.project.eshop_refact.domain.queue.WaitingQueueService;
 import com.project.eshop_refact.domain.order.strategy.PessimisticLockStrategy;
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,7 +44,7 @@ import static org.mockito.BDDMockito.given;
         "app.order.lock.wait-time=120",
         "logging.level.root=error"
 })
-public class OrderConcurrencyIntegrationTest {
+public class OrderConcurrencyIntegrationTest extends MariaDbRedisIntegrationTest {
 
     @Autowired private OrderService orderService;
     @Autowired private RedissonLockStockFacade redissonLockStockFacade;
@@ -105,7 +106,8 @@ public class OrderConcurrencyIntegrationTest {
             });
         }
 
-        latch.await();
+        assertThat(latch.await(2, TimeUnit.MINUTES)).isTrue();
+        executorService.shutdownNow();
 
         // Then
         Product updatedProduct = productRepository.findById(productId).orElseThrow();
@@ -208,7 +210,8 @@ public class OrderConcurrencyIntegrationTest {
             });
         }
 
-        latch.await();
+        assertThat(latch.await(2, TimeUnit.MINUTES)).isTrue();
+        executorService.shutdownNow();
         return System.currentTimeMillis() - startTime;
     }
 

--- a/src/test/java/com/project/eshop_refact/integration/OrderQueryIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/OrderQueryIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.project.eshop_refact.integration;
 
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
 import com.project.eshop_refact.domain.order.Order;
 import com.project.eshop_refact.domain.order.OrderItem;
 import com.project.eshop_refact.domain.product.Product;
@@ -34,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.jpa.properties.hibernate.default_batch_fetch_size=100"
 })
 @Transactional
-public class OrderQueryIntegrationTest {
+public class OrderQueryIntegrationTest extends MariaDbRedisIntegrationTest {
 
     @Autowired OrderRepository orderRepository;
     @Autowired OrderService orderService;

--- a/src/test/java/com/project/eshop_refact/integration/ProductCacheIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/ProductCacheIntegrationTest.java
@@ -4,6 +4,8 @@ import com.project.eshop_refact.domain.product.Product;
 import com.project.eshop_refact.domain.product.ProductDto;
 import com.project.eshop_refact.domain.product.ProductRepository;
 import com.project.eshop_refact.domain.product.ProductService;
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Cache-Aside 패턴에서의 데이터 조회(Put) 및 데이터 변경 시 무효화(Evict) 라이프사이클을 검증합니다.
  */
 @SpringBootTest
-public class ProductCacheIntegrationTest {
+public class ProductCacheIntegrationTest extends MariaDbRedisIntegrationTest {
 
     @Autowired private ProductService productService;
     @Autowired private ProductRepository productRepository;
@@ -31,6 +33,11 @@ public class ProductCacheIntegrationTest {
     void clearCache(){
         Cache cache = cacheManager.getCache("products");
         if(cache != null) cache.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/project/eshop_refact/integration/ProductRepositoryIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/ProductRepositoryIntegrationTest.java
@@ -4,10 +4,12 @@ import com.project.eshop_refact.global.config.QueryDslConfig;
 import com.project.eshop_refact.domain.product.Product;
 import com.project.eshop_refact.domain.product.ProductDto;
 import com.project.eshop_refact.domain.product.ProductRepository;
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -20,8 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * QueryDSL을 활용한 복합 조건 동적 쿼리와 No-Offset(Cursor) 기반 페이징 로직의 정합성을 검증합니다.
  */
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(QueryDslConfig.class) // QueryDSL JPAQueryFactory 빈 주입을 위한 설정 로드
-public class ProductRepositoryIntegrationTest {
+public class ProductRepositoryIntegrationTest extends MariaDbRedisIntegrationTest {
 
     @Autowired
     ProductRepository productRepository;

--- a/src/test/java/com/project/eshop_refact/integration/TestcontainersInfrastructureIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/TestcontainersInfrastructureIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.project.eshop_refact.integration;
+
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.Connection;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TestcontainersInfrastructureIntegrationTest extends MariaDbRedisIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Test
+    @DisplayName("MariaDB schema와 Redis 연결을 컨테이너 환경에서 검증한다")
+    void verifiesMariaDbSchemaAndRedisConnection() throws Exception {
+        try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
+            assertThat(connection.getMetaData().getDatabaseProductName()).isEqualTo("MariaDB");
+        }
+
+        Set<String> tables = Set.copyOf(jdbcTemplate.queryForList(
+                "select table_name from information_schema.tables where table_schema = database()",
+                String.class
+        ));
+        assertThat(tables).contains("users", "products", "orders", "order_item");
+
+        Long foreignKeyCount = jdbcTemplate.queryForObject(
+                "select count(*) from information_schema.referential_constraints where constraint_schema = database()",
+                Long.class
+        );
+        assertThat(foreignKeyCount).isNotNull().isGreaterThanOrEqualTo(3L);
+
+        try (var connection = redisConnectionFactory.getConnection()) {
+            assertThat(connection.ping()).isEqualTo("PONG");
+        }
+    }
+}

--- a/src/test/java/com/project/eshop_refact/integration/support/MariaDbRedisIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/support/MariaDbRedisIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.project.eshop_refact.integration.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.stream.Stream;
+
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public abstract class MariaDbRedisIntegrationTest {
+
+    private static final MariaDBContainer<?> MARIA_DB = new MariaDBContainer<>(
+            DockerImageName.parse("mariadb:11.8.6")
+    )
+            .withDatabaseName("eshop_test")
+            .withUsername("eshop")
+            .withPassword("eshop");
+
+    private static final GenericContainer<?> REDIS = new GenericContainer<>(
+            DockerImageName.parse("redis:7.4.5-alpine")
+    ).withExposedPorts(6379);
+
+    static {
+        try {
+            Startables.deepStart(Stream.of(MARIA_DB, REDIS)).join();
+        } catch (RuntimeException exception) {
+            throw new IllegalStateException(
+                    "통합 테스트용 MariaDB/Redis 컨테이너를 시작하지 못했습니다. Docker 실행 상태와 이미지 다운로드 가능 여부를 확인하세요.",
+                    exception
+            );
+        }
+    }
+
+    @Autowired(required = false)
+    private StringRedisTemplate redisTemplate;
+
+    @DynamicPropertySource
+    protected static void registerContainerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MARIA_DB::getJdbcUrl);
+        registry.add("spring.datasource.username", MARIA_DB::getUsername);
+        registry.add("spring.datasource.password", MARIA_DB::getPassword);
+        registry.add("spring.datasource.driver-class-name", MARIA_DB::getDriverClassName);
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+        registry.add("spring.docker.compose.enabled", () -> false);
+    }
+
+    @BeforeEach
+    protected void clearSharedRedisState() {
+        if (redisTemplate != null) {
+            redisTemplate.execute((RedisCallback<Void>) connection -> {
+                connection.serverCommands().flushAll();
+                return null;
+            });
+        }
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,11 +1,4 @@
 spring:
-
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=MariaDB;DB_CLOSE_DELAY=-1
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -13,11 +6,11 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MariaDBDialect
 
   data:
     redis:
-      # 향후 Testcontainers 또는 Embedded Redis 도입을 위한 환경변수 처리
+      # 통합 테스트에서는 Testcontainers가 동적 host/port를 주입합니다.
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 test:


### PR DESCRIPTION
## 변경 사항
- #33의 MariaDB/Hibernate schema 관리 결정을 기준으로 MariaDB 11.8.6과 Redis 7.4.5 Testcontainers 환경을 추가했습니다.
- 통합 테스트에 동적 datasource/Redis 접속 정보를 주입하고 테스트 클래스별 schema 및 Redis 상태를 격리했습니다.
- 실제 MariaDB 핵심 테이블·외래키와 Redis 연결을 확인하는 infrastructure smoke test를 추가했습니다.
- 동시성 테스트 executor 종료와 timeout을 보강하고, 가용성 테스트가 비관적 락 대기 중 DB connection 점유를 안정적으로 재현하도록 수정했습니다.
- 로컬/CI 공통 실행 명령을 README와 테스트 문서에 반영했습니다.
- 기존 로컬 커밋 `b186e1a`를 포함하되, 후속 커밋에서 AGENTS.md를 #33의 MariaDB 정책에 맞추고 이슈 설계 승인·구현 승인·Git 작업 승인을 명확히 분리했습니다.

## 검증
- `./gradlew testClasses`
- `./gradlew integrationTest --tests com.project.eshop_refact.integration.TestcontainersInfrastructureIntegrationTest`
- `./gradlew integrationTest`
- `./gradlew integrationTest --rerun-tasks`
- `./gradlew verifyChange`
- `git diff --check`
- repository hygiene 및 Stop Hook 비밀정보 검사

Closes #16