### PR TITLE
feat: add browser entrypoint for API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Spring Boot는 `docker-compose.dev.yml`의 Redis를 자동으로 시작하고 �
 
 `.env`는 애플리케이션과 Docker Compose가 자동으로 읽습니다. Redis 자동 실행을 위해 Docker Desktop은 실행 중이어야 합니다.
 
+- API 진입점: <http://localhost:8080> (Swagger UI로 이동)
 - Swagger UI: <http://localhost:8080/swagger-ui.html>
 - Health endpoint: <http://localhost:8080/actuator/health> (인증 없이 상태만 공개, 상세 정보 비공개)
 

--- a/src/main/java/com/project/eshop_refact/domain/user/UserController.java
+++ b/src/main/java/com/project/eshop_refact/domain/user/UserController.java
@@ -1,7 +1,13 @@
 package com.project.eshop_refact.domain.user;
 
 import com.project.eshop_refact.global.common.ApiResponse;
+import com.project.eshop_refact.global.common.ErrorResponse;
 import com.project.eshop_refact.global.security.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
+@Tag(name = "사용자", description = "회원가입, 로그인 및 토큰 관리 API")
 public class UserController {
 
     private final UserService userService;
@@ -19,6 +26,21 @@ public class UserController {
     /**
      * 회원가입 API
      */
+    @Operation(summary = "회원가입", description = "이메일, 비밀번호, 사용자 이름으로 일반 사용자 계정을 생성합니다.")
+    @SecurityRequirements
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "입력값 오류 또는 이미 가입된 이메일",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "동시에 등록된 중복 이메일",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(@RequestBody @Valid UserDto.SignupRequest requestDto){
         userService.signup(requestDto);
@@ -29,6 +51,8 @@ public class UserController {
      * 로그인 API
      * 인증 성공 시 클라이언트에게 엑세스(Access) 및 리프레시(Refresh) 토큰을 발급합니다.
      */
+    @Operation(summary = "로그인", description = "이메일과 비밀번호를 검증하고 Access/Refresh Token을 발급합니다.")
+    @SecurityRequirements
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<UserDto.TokenResponse>> login(@RequestBody @Valid UserDto.LoginRequest requestDto){
         UserDto.TokenResponse tokenDto = userService.login(requestDto);
@@ -39,6 +63,8 @@ public class UserController {
      * 토큰 재발급 API
      * 리프레시 토큰을 검증하여 만료된 엑세스 토큰을 갱신합니다.
      */
+    @Operation(summary = "토큰 재발급", description = "유효한 Refresh Token으로 Access/Refresh Token을 재발급합니다.")
+    @SecurityRequirements
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<UserDto.TokenResponse>> reissue(@RequestBody @Valid UserDto.RefreshRequest requestDto) {
         UserDto.TokenResponse tokenDto = userService.reissue(requestDto);
@@ -49,6 +75,7 @@ public class UserController {
      * 로그아웃 API
      * 현재 사용자의 엑세스 토큰을 무효화하고 인증 상태를 해제합니다.
      */
+    @Operation(summary = "로그아웃", description = "Refresh Token을 제거하고 현재 Access Token을 블랙리스트에 등록합니다.")
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader String authorizationHeader, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         String accessToken = authorizationHeader.substring(7);
@@ -57,5 +84,3 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success("로그아웃 성공"));
     }
 }
-
-

--- a/src/main/java/com/project/eshop_refact/domain/user/UserDto.java
+++ b/src/main/java/com/project/eshop_refact/domain/user/UserDto.java
@@ -1,5 +1,6 @@
 package com.project.eshop_refact.domain.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -22,17 +23,20 @@ public class UserDto {
 
         @NotBlank(message = "이메일은 필수 입력")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Schema(description = "가입할 이메일", example = "user@example.com")
         private String email;
 
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
         // 최소 8자, 하나 이상의 문자, 하나의 숫자 및 하나의 특수 문자 포함 정규식
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
                 message = "비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다.")
+        @Schema(description = "8자 이상이며 영문, 숫자, 특수문자를 포함한 비밀번호", example = "password123!")
         // Plain Text -> DB 저장 X -> Service에서 암호화 후 저장.
         private String password;
 
         @NotBlank(message = "사용자 이름은 필수 입력 값입니다.")
         @Size(min = 2, max = 10, message = "이름은 2자 이상 10자 이하로 입력해주세요.")
+        @Schema(description = "2자 이상 10자 이하의 사용자 이름", example = "tester")
         private String username;
 
     }

--- a/src/main/java/com/project/eshop_refact/global/config/WebConfig.java
+++ b/src/main/java/com/project/eshop_refact/global/config/WebConfig.java
@@ -4,6 +4,7 @@ import com.project.eshop_refact.global.interceptor.QueueInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
@@ -15,6 +16,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final QueueInterceptor queueInterceptor;
+
+    /**
+     * 브라우저로 루트 경로에 접근하면 API 문서로 안내합니다.
+     */
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addRedirectViewController("/", "/swagger-ui.html");
+    }
 
     /**
      * 대기열 인터셉터 등록

--- a/src/main/java/com/project/eshop_refact/global/exception/ErrorCode.java
+++ b/src/main/java/com/project/eshop_refact/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // --- Global ---
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."), // @Valid 검증 실패 시
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."), // 예상치 못한 에러
     LOCK_ACQUISITION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "현재 요청이 많아 처리가 지연되고 있습니다."),
     DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),

--- a/src/main/java/com/project/eshop_refact/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/eshop_refact/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.project.eshop_refact.global.exception;
 import com.project.eshop_refact.global.common.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -45,6 +47,22 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
 
         return new ResponseEntity<>(ErrorResponse.of(errorCode,message), errorCode.getHttpStatus());
+    }
+
+    /**
+     * 지원하지 않는 HTTP 메서드 요청을 405 응답으로 변환합니다.
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.warn("HTTP Method Not Supported : {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(errorCode.getHttpStatus());
+        if (e.getSupportedHttpMethods() != null) {
+            response.allow(e.getSupportedHttpMethods().toArray(HttpMethod[]::new));
+        }
+
+        return response.body(ErrorResponse.of(errorCode));
     }
 
     /**

--- a/src/main/java/com/project/eshop_refact/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/eshop_refact/global/security/JwtAuthenticationFilter.java
@@ -35,7 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request){
         String path = request.getRequestURI();
-        return path.equals("/api/users/signup")
+        return path.equals("/")
+                || path.equals("/api/users/signup")
                 || path.equals("/api/users/login")
                 || path.equals("/api/users/reissue")
                 || path.startsWith("/v3/api-docs")

--- a/src/main/java/com/project/eshop_refact/global/security/SecurityConfig.java
+++ b/src/main/java/com/project/eshop_refact/global/security/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authz ->authz
                         .requestMatchers("/api/users/signup", "/api/users/login", "/api/users/reissue").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                         .requestMatchers("/actuator/**").denyAll()
                         .requestMatchers("/api/orders/queue").authenticated()// 테스트 전용 허용 명시

--- a/src/test/java/com/project/eshop_refact/controller/UserControllerTest.java
+++ b/src/test/java/com/project/eshop_refact/controller/UserControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -26,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -57,6 +59,15 @@ class UserControllerTest {
     RedisTemplate<String, String> redisTemplate;
 
     @Test
+    @DisplayName("루트 경로 접근: Swagger UI로 리다이렉트")
+    @WithMockUser
+    void root_redirects_to_swagger_ui() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/swagger-ui.html"));
+    }
+
+    @Test
     @DisplayName("회원가입 성공: 201 상태코드 반환")
     @WithMockUser // 컨트롤러 접근 권한 검증을 통과하기 위한 Mock 인증 객체 주입
     void signup_success() throws Exception {
@@ -74,6 +85,18 @@ class UserControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.message").value("회원가입 성공"))
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입 실패: GET 요청은 405와 허용 메서드를 반환")
+    @WithMockUser
+    void signup_fail_method_not_allowed() throws Exception {
+        mockMvc.perform(get("/api/users/signup"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().string(HttpHeaders.ALLOW, "POST"))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.code").value("METHOD_NOT_ALLOWED"))
+                .andExpect(jsonPath("$.message").value("지원하지 않는 HTTP 메서드입니다."));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- redirect the application root to Swagger UI
- return a structured 405 response with an Allow header for unsupported HTTP methods
- document public user APIs and signup examples in OpenAPI
- add MVC regression coverage and update the README entrypoint

## Verification
- `./gradlew test --tests com.project.eshop_refact.controller.UserControllerTest`
- `./gradlew unitTest`
- `./gradlew verifyChange`
- runtime checks for `/`, `GET /api/users/signup`, and `/v3/api-docs`
- `git diff --check`