### PR TITLE
fix: 주문 취소를 멱등하게 처리

### DIFF
--- a/src/main/java/com/project/eshop_refact/domain/order/Order.java
+++ b/src/main/java/com/project/eshop_refact/domain/order/Order.java
@@ -69,7 +69,7 @@ public class Order {
      * 주문 상태를 검증한 후 취소 처리 및 하위 주문 상품의 재고를 복구합니다.
      */
     public void cancel(){
-        if(this.status == OrderStatus.COMPLETED){
+        if(this.status != OrderStatus.ORDER){
             throw new BusinessException(ErrorCode.CANNOT_CANCEL_ORDER);
         }
 
@@ -78,5 +78,9 @@ public class Order {
         for(OrderItem orderItem : orderItems){
             orderItem.getProduct().addStock(orderItem.getCount());
         }
+    }
+
+    public boolean isCancelled() {
+        return this.status == OrderStatus.CANCEL;
     }
 }

--- a/src/main/java/com/project/eshop_refact/domain/order/OrderRepository.java
+++ b/src/main/java/com/project/eshop_refact/domain/order/OrderRepository.java
@@ -1,13 +1,18 @@
 package com.project.eshop_refact.domain.order;
 
 import com.project.eshop_refact.domain.user.User;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
@@ -17,6 +22,14 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findAllByUserOrderByIdDesc(User user);
 
     Page<Order> findAllByUser(User user, Pageable pageable);
+
+    /**
+     * 같은 주문의 동시 취소 요청을 직렬화하고 잠금 획득 후 최신 상태를 다시 확인합니다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "10000"))
+    @Query("select o from Order o where o.id = :orderId")
+    Optional<Order> findByIdForUpdate(@Param("orderId") Long orderId);
 
     /**
      * (Legacy) Fetch Join을 활용한 사용자 주문 상세 조회

--- a/src/main/java/com/project/eshop_refact/domain/order/OrderService.java
+++ b/src/main/java/com/project/eshop_refact/domain/order/OrderService.java
@@ -72,12 +72,17 @@ public class OrderService {
 
     @Transactional
     public void cancelOrder(Long orderId, Long userId) {
-        Order order = orderRepository.findById(orderId)
+        Order order = orderRepository.findByIdForUpdate(orderId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 
         if(!order.getUser().getId().equals(userId)){
             throw new BusinessException(ErrorCode.FORBIDDEN_ACCESS);
         }
+
+        if (order.isCancelled()) {
+            return;
+        }
+
         order.cancel();
 
         // 재고 복구 후, 변경된 상품의 캐시를 무효화하기 위해 이벤트를 발행합니다.

--- a/src/main/java/com/project/eshop_refact/global/exception/ErrorCode.java
+++ b/src/main/java/com/project/eshop_refact/global/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
 
     // --- Order ---
     ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
-    CANNOT_CANCEL_ORDER(HttpStatus.BAD_REQUEST, "이미 배송이 완료되어 주문을 취소할 수 없습니다."),
+    CANNOT_CANCEL_ORDER(HttpStatus.BAD_REQUEST, "현재 주문 상태에서는 주문을 취소할 수 없습니다."),
 
     // --- Queue ---
     QUEUE_WAITING(HttpStatus.TOO_MANY_REQUESTS, "현재 접속량이 많아 대기 중입니다. 잠시 후 다시 시도해 주세요.");

--- a/src/test/java/com/project/eshop_refact/domain/OrderTest.java
+++ b/src/test/java/com/project/eshop_refact/domain/OrderTest.java
@@ -80,4 +80,23 @@ public class OrderTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CANNOT_CANCEL_ORDER);
     }
+
+    @Test
+    @DisplayName("이미 취소된 주문은 다시 취소할 수 없고 재고도 다시 복구되지 않는다")
+    void cannotCancelAlreadyCancelledOrder() {
+        // Given
+        User user = new User("test@test.com", "1234", "tester", UserRoleEnum.USER);
+        Product product = new Product("신발", 10000, 100);
+        product.removeStock(2);
+        OrderItem orderItem = OrderItem.createOrderItem(product, 2);
+        Order order = Order.createOrder(user, List.of(orderItem));
+        order.cancel();
+
+        // When & Then
+        assertThatThrownBy(order::cancel)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CANNOT_CANCEL_ORDER);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL);
+        assertThat(product.getStockQuantity()).isEqualTo(100);
+    }
 }

--- a/src/test/java/com/project/eshop_refact/integration/OrderCancellationIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/OrderCancellationIntegrationTest.java
@@ -1,0 +1,222 @@
+package com.project.eshop_refact.integration;
+
+import com.project.eshop_refact.domain.order.Order;
+import com.project.eshop_refact.domain.order.OrderItem;
+import com.project.eshop_refact.domain.order.OrderRepository;
+import com.project.eshop_refact.domain.order.OrderService;
+import com.project.eshop_refact.domain.order.OrderStatus;
+import com.project.eshop_refact.domain.order.RedissonLockStockFacade;
+import com.project.eshop_refact.domain.product.Product;
+import com.project.eshop_refact.domain.product.ProductDto;
+import com.project.eshop_refact.domain.product.ProductRepository;
+import com.project.eshop_refact.domain.product.ProductService;
+import com.project.eshop_refact.domain.user.User;
+import com.project.eshop_refact.domain.user.UserRepository;
+import com.project.eshop_refact.domain.user.UserRoleEnum;
+import com.project.eshop_refact.global.exception.BusinessException;
+import com.project.eshop_refact.global.exception.ErrorCode;
+import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(properties = "app.order.lock.wait-time=30")
+class OrderCancellationIntegrationTest extends MariaDbRedisIntegrationTest {
+
+    private static final int INITIAL_STOCK = 10;
+    private static final int ORDER_COUNT = 2;
+
+    @Autowired
+    private OrderService orderService;
+    @Autowired
+    private RedissonLockStockFacade redissonLockStockFacade;
+    @Autowired
+    private ProductService productService;
+    @Autowired
+    private OrderRepository orderRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CacheManager cacheManager;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @AfterEach
+    void tearDown() {
+        orderRepository.deleteAll();
+        productRepository.deleteAll();
+        userRepository.deleteAll();
+        productCache().clear();
+    }
+
+    @Test
+    @DisplayName("순차 중복 취소는 성공하지만 재고와 캐시는 한 번만 변경한다")
+    void sequentialCancellationIsIdempotent() {
+        TestOrder testOrder = createOrder();
+
+        redissonLockStockFacade.cancelOrder(testOrder.orderId(), testOrder.ownerId());
+        ProductDto.Response cachedProduct = productService.getProductById(testOrder.productId());
+        assertThat(cachedProduct.getStockQuantity()).isEqualTo(INITIAL_STOCK);
+        assertThat(productCache().get(testOrder.productId())).isNotNull();
+
+        redissonLockStockFacade.cancelOrder(testOrder.orderId(), testOrder.ownerId());
+
+        assertThat(orderRepository.findById(testOrder.orderId()).orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.CANCEL);
+        assertThat(productRepository.findById(testOrder.productId()).orElseThrow().getStockQuantity())
+                .isEqualTo(INITIAL_STOCK);
+        assertThat(productCache().get(testOrder.productId())).isNotNull();
+    }
+
+    @Test
+    @DisplayName("같은 주문의 동시 취소는 주문 행에서 직렬화되어 재고를 한 번만 복구한다")
+    void concurrentCancellationRestoresStockOnce() throws InterruptedException {
+        TestOrder testOrder = createOrder();
+        productService.getProductById(testOrder.productId());
+
+        int requestCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch ready = new CountDownLatch(requestCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch completed = new CountDownLatch(requestCount);
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+        try {
+            for (int i = 0; i < requestCount; i++) {
+                executor.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                        orderService.cancelOrder(testOrder.orderId(), testOrder.ownerId());
+                    } catch (InterruptedException exception) {
+                        Thread.currentThread().interrupt();
+                        failures.add(exception);
+                    } catch (Throwable throwable) {
+                        failures.add(throwable);
+                    } finally {
+                        completed.countDown();
+                    }
+                });
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            assertThat(completed.await(30, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+
+        assertThat(failures).isEmpty();
+        assertThat(orderRepository.findById(testOrder.orderId()).orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.CANCEL);
+        assertThat(productRepository.findById(testOrder.productId()).orElseThrow().getStockQuantity())
+                .isEqualTo(INITIAL_STOCK);
+        assertThat(productCache().get(testOrder.productId())).isNull();
+    }
+
+    @Test
+    @DisplayName("취소 캐시는 트랜잭션 커밋 전에는 유지되고 커밋 후 제거된다")
+    void cacheIsEvictedOnlyAfterCommit() {
+        TestOrder testOrder = createOrder();
+        productService.getProductById(testOrder.productId());
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            orderService.cancelOrder(testOrder.orderId(), testOrder.ownerId());
+            assertThat(productCache().get(testOrder.productId())).isNotNull();
+        });
+
+        assertThat(productCache().get(testOrder.productId())).isNull();
+        assertThat(productService.getProductById(testOrder.productId()).getStockQuantity())
+                .isEqualTo(INITIAL_STOCK);
+    }
+
+    @Test
+    @DisplayName("취소 트랜잭션이 롤백되면 주문 상태와 재고 및 기존 캐시가 유지된다")
+    void rollbackKeepsOrderStockAndCache() {
+        TestOrder testOrder = createOrder();
+        ProductDto.Response cachedProduct = productService.getProductById(testOrder.productId());
+        assertThat(cachedProduct.getStockQuantity()).isEqualTo(INITIAL_STOCK - ORDER_COUNT);
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            orderService.cancelOrder(testOrder.orderId(), testOrder.ownerId());
+            assertThat(productCache().get(testOrder.productId())).isNotNull();
+            status.setRollbackOnly();
+        });
+
+        assertThat(orderRepository.findById(testOrder.orderId()).orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.ORDER);
+        assertThat(productRepository.findById(testOrder.productId()).orElseThrow().getStockQuantity())
+                .isEqualTo(INITIAL_STOCK - ORDER_COUNT);
+        assertThat(productCache().get(testOrder.productId())).isNotNull();
+        assertThat(productService.getProductById(testOrder.productId()).getStockQuantity())
+                .isEqualTo(INITIAL_STOCK - ORDER_COUNT);
+    }
+
+    @Test
+    @DisplayName("다른 사용자는 이미 생성된 주문을 취소할 수 없다")
+    void otherUserCannotCancelOrder() {
+        TestOrder testOrder = createOrder();
+        User otherUser = userRepository.save(
+                new User("other@test.com", "1234", "other", UserRoleEnum.USER)
+        );
+        productService.getProductById(testOrder.productId());
+
+        assertThatThrownBy(() -> redissonLockStockFacade.cancelOrder(testOrder.orderId(), otherUser.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_ACCESS);
+
+        assertThat(orderRepository.findById(testOrder.orderId()).orElseThrow().getStatus())
+                .isEqualTo(OrderStatus.ORDER);
+        assertThat(productRepository.findById(testOrder.productId()).orElseThrow().getStockQuantity())
+                .isEqualTo(INITIAL_STOCK - ORDER_COUNT);
+        assertThat(productCache().get(testOrder.productId())).isNotNull();
+    }
+
+    private TestOrder createOrder() {
+        return new TransactionTemplate(transactionManager).execute(status -> {
+            User owner = userRepository.save(
+                    new User("owner@test.com", "1234", "owner", UserRoleEnum.USER)
+            );
+            Product product = productRepository.save(
+                    new Product("취소 테스트 상품", 10000, INITIAL_STOCK)
+            );
+            product.removeStock(ORDER_COUNT);
+
+            OrderItem orderItem = OrderItem.createOrderItem(product, ORDER_COUNT);
+            Order order = orderRepository.save(Order.createOrder(owner, List.of(orderItem)));
+
+            return new TestOrder(order.getId(), owner.getId(), product.getId());
+        });
+    }
+
+    private Cache productCache() {
+        Cache cache = cacheManager.getCache("products");
+        if (cache == null) {
+            throw new IllegalStateException("products 캐시가 구성되지 않았습니다.");
+        }
+        return cache;
+    }
+
+    private record TestOrder(Long orderId, Long ownerId, Long productId) {
+    }
+}

--- a/src/test/java/com/project/eshop_refact/service/OrderServiceTest.java
+++ b/src/test/java/com/project/eshop_refact/service/OrderServiceTest.java
@@ -2,6 +2,7 @@ package com.project.eshop_refact.service;
 
 import com.project.eshop_refact.domain.order.*;
 import com.project.eshop_refact.domain.product.Product;
+import com.project.eshop_refact.domain.product.ProductCacheEvictEvent;
 import com.project.eshop_refact.domain.user.User;
 import com.project.eshop_refact.domain.user.UserRoleEnum;
 import com.project.eshop_refact.global.exception.BusinessException;
@@ -27,6 +28,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -150,7 +153,7 @@ public class OrderServiceTest {
 
         assertThat(product.getStockQuantity()).isEqualTo(3);
 
-        given(orderRepository.findById(10L)).willReturn(Optional.of(order));
+        given(orderRepository.findByIdForUpdate(10L)).willReturn(Optional.of(order));
 
         // When
         orderService.cancelOrder(10L, 1L);
@@ -159,6 +162,28 @@ public class OrderServiceTest {
         // 취소 로직 내부에서 도메인 메서드(addStock)가 호출되어 재고가 정상 복구되었는지 확인
         assertThat(product.getStockQuantity()).isEqualTo(5);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL);
+        verify(eventPublisher).publishEvent(any(ProductCacheEvictEvent.class));
+    }
+
+    @Test
+    @DisplayName("주문 취소 멱등 성공: 이미 취소된 주문은 재고와 캐시를 다시 변경하지 않는다")
+    void cancelOrder_alreadyCancelled() {
+        // Given
+        Product product = new Product("item", 10000, 5);
+        User user = new User("test", "pw", "user", UserRoleEnum.USER);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        product.removeStock(2);
+
+        Order order = Order.createOrder(user, List.of(OrderItem.createOrderItem(product, 2)));
+        given(orderRepository.findByIdForUpdate(10L)).willReturn(Optional.of(order));
+
+        orderService.cancelOrder(10L, 1L);
+        orderService.cancelOrder(10L, 1L);
+
+        // Then
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCEL);
+        assertThat(product.getStockQuantity()).isEqualTo(5);
+        verify(eventPublisher, times(1)).publishEvent(any(ProductCacheEvictEvent.class));
     }
 
     @Test
@@ -167,7 +192,7 @@ public class OrderServiceTest {
         // Given
         Long orderId = 999L;
         Long userId = 1L;
-        given(orderRepository.findById(orderId)).willReturn(Optional.empty());
+        given(orderRepository.findByIdForUpdate(orderId)).willReturn(Optional.empty());
 
         // When & Then
         assertThatThrownBy(() -> orderService.cancelOrder(orderId,userId))
@@ -189,11 +214,12 @@ public class OrderServiceTest {
         Order order = new Order();
         ReflectionTestUtils.setField(order, "user", owner);
 
-        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+        given(orderRepository.findByIdForUpdate(orderId)).willReturn(Optional.of(order));
 
         // When & Then: 타인(2L)이 취소 요청 시 예외 발생 확인
         assertThatThrownBy(() -> orderService.cancelOrder(orderId, requesterId))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_ACCESS);
+        verify(eventPublisher, never()).publishEvent(any());
     }
 }


### PR DESCRIPTION
## 변경 사항
- 주문 상태 전이를 ORDER에서 CANCEL로 제한합니다.
- 주문 행 비관적 잠금과 잠금 후 상태 재검증으로 동시 취소를 직렬화합니다.
- 이미 취소된 요청은 재고 및 캐시 이벤트를 반복 처리하지 않고 성공 반환합니다.
- 커밋 후 캐시 제거와 롤백 정합성을 MariaDB·Redis 통합 테스트로 검증합니다.

## 검증
- ./gradlew test --tests com.project.eshop_refact.domain.OrderTest --tests com.project.eshop_refact.service.OrderServiceTest
- ./gradlew unitTest
- ./gradlew integrationTest --tests com.project.eshop_refact.integration.OrderCancellationIntegrationTest
- ./gradlew integrationTest
- ./gradlew verifyChange
- git diff --check

Closes #11