### PR TITLE
fix: 로그아웃 Authorization 헤더 계약 보강

### DIFF
--- a/src/main/java/com/project/eshop_refact/domain/user/UserController.java
+++ b/src/main/java/com/project/eshop_refact/domain/user/UserController.java
@@ -2,6 +2,8 @@ package com.project.eshop_refact.domain.user;
 
 import com.project.eshop_refact.global.common.ApiResponse;
 import com.project.eshop_refact.global.common.ErrorResponse;
+import com.project.eshop_refact.global.exception.BusinessException;
+import com.project.eshop_refact.global.exception.ErrorCode;
 import com.project.eshop_refact.global.security.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,8 +12,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -20,6 +24,8 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/users")
 @Tag(name = "사용자", description = "회원가입, 로그인 및 토큰 관리 API")
 public class UserController {
+
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private final UserService userService;
 
@@ -77,10 +83,23 @@ public class UserController {
      */
     @Operation(summary = "로그아웃", description = "Refresh Token을 제거하고 현재 Access Token을 블랙리스트에 등록합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader String authorizationHeader, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        String accessToken = authorizationHeader.substring(7);
+    public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
+                                                    @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        String accessToken = extractAccessToken(authorizationHeader);
 
         userService.logout(accessToken, userDetails.getUser().getEmail());
         return ResponseEntity.ok(ApiResponse.success("로그아웃 성공"));
+    }
+
+    private String extractAccessToken(String authorizationHeader) {
+        if (!StringUtils.hasText(authorizationHeader) || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+
+        String accessToken = authorizationHeader.substring(BEARER_PREFIX.length());
+        if (!StringUtils.hasText(accessToken)) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+        return accessToken;
     }
 }

--- a/src/test/java/com/project/eshop_refact/config/UserLogoutSecurityTest.java
+++ b/src/test/java/com/project/eshop_refact/config/UserLogoutSecurityTest.java
@@ -1,0 +1,106 @@
+package com.project.eshop_refact.config;
+
+import com.project.eshop_refact.domain.queue.WaitingQueueService;
+import com.project.eshop_refact.domain.user.UserController;
+import com.project.eshop_refact.domain.user.UserService;
+import com.project.eshop_refact.global.security.JwtAuthenticationFilter;
+import com.project.eshop_refact.global.security.JwtUtil;
+import com.project.eshop_refact.global.security.RestAccessDeniedHandler;
+import com.project.eshop_refact.global.security.RestAuthenticationEntryPoint;
+import com.project.eshop_refact.global.security.SecurityConfig;
+import com.project.eshop_refact.global.security.UserDetailsServiceImpl;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UserController.class)
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationFilter.class,
+        RestAuthenticationEntryPoint.class,
+        RestAccessDeniedHandler.class
+})
+class UserLogoutSecurityTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    JwtUtil jwtUtil;
+
+    @MockBean
+    UserDetailsServiceImpl userDetailsServiceImpl;
+
+    @MockBean
+    RedisTemplate<String, String> redisTemplate;
+
+    @MockBean
+    WaitingQueueService waitingQueueService;
+
+    @Test
+    @DisplayName("로그아웃 보안 경계: Authorization 헤더 누락을 401로 거절한다")
+    void rejects_missing_authorization_header() throws Exception {
+        assertUnauthorized(post("/api/users/logout"));
+    }
+
+    @Test
+    @DisplayName("로그아웃 보안 경계: 잘못된 인증 scheme을 401로 거절한다")
+    void rejects_invalid_authorization_scheme() throws Exception {
+        assertUnauthorized(post("/api/users/logout")
+                .header(HttpHeaders.AUTHORIZATION, "Basic access-token"));
+    }
+
+    @Test
+    @DisplayName("로그아웃 보안 경계: 빈 Bearer Token을 401로 거절한다")
+    void rejects_empty_bearer_token() throws Exception {
+        given(jwtUtil.getClaimsIfValid("")).willReturn(null);
+
+        assertUnauthorized(post("/api/users/logout")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer "));
+    }
+
+    @Test
+    @DisplayName("로그아웃 보안 경계: Refresh Token을 401로 거절한다")
+    void rejects_refresh_token() throws Exception {
+        Claims claims = mock(Claims.class);
+        given(jwtUtil.getClaimsIfValid("refresh-token")).willReturn(claims);
+        given(claims.get("type")).willReturn("REFRESH");
+
+        mockMvc.perform(post("/api/users/logout")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer refresh-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_TOKEN"))
+                .andExpect(content().string(not(containsString("refresh-token"))));
+
+        verifyNoInteractions(userService);
+    }
+
+    private void assertUnauthorized(MockHttpServletRequestBuilder request) throws Exception {
+        mockMvc.perform(request)
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_TOKEN"));
+
+        verifyNoInteractions(userService);
+    }
+}

--- a/src/test/java/com/project/eshop_refact/controller/UserControllerTest.java
+++ b/src/test/java/com/project/eshop_refact/controller/UserControllerTest.java
@@ -3,9 +3,12 @@ package com.project.eshop_refact.controller;
 import com.project.eshop_refact.domain.user.UserController;
 import com.project.eshop_refact.global.security.JwtUtil;
 import com.project.eshop_refact.global.security.SecurityConfig;
+import com.project.eshop_refact.domain.user.User;
 import com.project.eshop_refact.domain.user.UserDto;
+import com.project.eshop_refact.domain.user.UserRoleEnum;
 import com.project.eshop_refact.global.exception.BusinessException;
 import com.project.eshop_refact.global.exception.ErrorCode;
+import com.project.eshop_refact.global.security.UserDetailsImpl;
 import com.project.eshop_refact.global.security.UserDetailsServiceImpl;
 import com.project.eshop_refact.domain.user.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +29,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -200,5 +206,50 @@ class UserControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest()) // 또는 401(Unauthorized)
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공: Bearer 접두사를 제외한 Access Token을 전달한다")
+    void logout_success() throws Exception {
+        UserDetailsImpl userDetails = testUserDetails();
+
+        mockMvc.perform(post("/api/users/logout")
+                        .with(csrf())
+                        .with(user(userDetails))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer access-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그아웃 성공"));
+
+        verify(userService).logout("access-token", "test@email.com");
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패: 잘못된 인증 scheme은 401을 반환한다")
+    void logout_rejects_invalid_scheme() throws Exception {
+        mockMvc.perform(post("/api/users/logout")
+                        .with(csrf())
+                        .with(user(testUserDetails()))
+                        .header(HttpHeaders.AUTHORIZATION, "Token access-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_TOKEN"));
+
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패: 빈 Bearer Token은 401을 반환한다")
+    void logout_rejects_empty_bearer_token() throws Exception {
+        mockMvc.perform(post("/api/users/logout")
+                        .with(csrf())
+                        .with(user(testUserDetails()))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer "))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("INVALID_TOKEN"));
+
+        verifyNoInteractions(userService);
+    }
+
+    private UserDetailsImpl testUserDetails() {
+        return new UserDetailsImpl(new User("test@email.com", "password", "tester", UserRoleEnum.USER));
     }
 }

--- a/src/test/java/com/project/eshop_refact/service/UserServiceTest.java
+++ b/src/test/java/com/project/eshop_refact/service/UserServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -109,5 +110,25 @@ class UserServiceTest {
         // 반환된 응답 DTO에 토큰 정보가 올바르게 매핑되었는지 검증합니다.
         assertThat(response.getAccessToken()).isEqualTo("access");
         assertThat(response.getRefreshToken()).isEqualTo("refresh");
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 시 Refresh Token을 삭제하고 Access Token을 남은 만료 시간 동안 차단한다")
+    void logout_success() {
+        String accessToken = "access-token";
+        String email = "test@test.com";
+        long expiration = System.currentTimeMillis() + 60_000;
+        when(jwtUtil.getExpiration(accessToken)).thenReturn(expiration);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        userService.logout(accessToken, email);
+
+        verify(redisTemplate).delete("RT:" + email);
+        verify(valueOperations).set(
+                eq("BLACKLIST:" + accessToken),
+                eq("logout"),
+                longThat(ttl -> ttl > 0 && ttl <= 60_000),
+                eq(TimeUnit.MILLISECONDS)
+        );
     }
 }


### PR DESCRIPTION
## 변경 사항
- 로그아웃 API가 표준 Authorization 헤더를 명시적으로 사용하도록 변경
- Bearer 접두사와 빈 토큰을 안전하게 검증하고 access token만 서비스에 전달
- 헤더 누락, 잘못된 scheme, 빈 토큰, refresh token에 대한 controller/security 회귀 테스트 추가
- refresh token 삭제와 access token blacklist TTL 동작 검증

## 검증
- ./gradlew test --tests '*UserControllerTest' --tests '*UserLogoutSecurityTest' --tests '*UserServiceTest'
- ./gradlew unitTest
- ./gradlew verifyChange
- git diff --check

Closes #21