### PR TITLE
docs: 검증 증거에 맞춰 프로젝트 설명 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # E-Shop
 
-### 동시 주문의 재고 정합성과 주문 폭주 상황의 조회 가용성을 함께 다루는 이커머스 백엔드
+### 고트래픽 주문·재고 정합성과 상품 단위 대기열을 검증하는 이커머스 백엔드 PoC
 
 [![Build and Publish Image](https://github.com/juhwanz/eshop-refac/actions/workflows/deploy.yml/badge.svg)](https://github.com/juhwanz/eshop-refac/actions/workflows/deploy.yml)
 [![Secret Scan](https://github.com/juhwanz/eshop-refac/actions/workflows/secret-scan.yml/badge.svg)](https://github.com/juhwanz/eshop-refac/actions/workflows/secret-scan.yml)
@@ -17,28 +17,28 @@
 
 ## 프로젝트 소개
 
-E-Shop은 CRUD 기능의 수보다 **트래픽이 몰릴 때 어떤 불변조건을 지켜야 하는가**에 집중한 Spring Boot 기반 백엔드 프로젝트입니다.
+E-Shop은 CRUD 기능의 수보다 **트래픽이 몰릴 때 어떤 불변조건을 지켜야 하는가**에 집중한 Spring Boot 기반 백엔드 PoC입니다.
 
-- 동시에 같은 상품을 주문해도 실제 재고보다 많이 판매하지 않습니다.
+- 지원하는 주문 경로에서 상품별 락과 재고 검증으로 동시 차감을 직렬화하고, DB CHECK로 음수 재고 저장을 차단합니다.
 - 분산 락 대기를 DB 트랜잭션 밖에 두어 커넥션 점유 시간을 줄입니다.
-- 동일 주문 요청은 사용자별 멱등성 키로 중복 처리를 방지합니다.
+- 동일 주문 요청은 Redis 캐시와 DB 유일 제약으로 기존 결과를 복구합니다.
 - 대기열, 캐시와 커서 기반 페이지 조회처럼 트래픽 증가 후 드러나는 문제를 함께 다룹니다.
 - 보안 검사와 안전한 테스트 범위를 CI에서 자동 검증합니다.
 
-> 이 문서는 2026-09-09 기준 구현 상태를 설명합니다. 진행 중인 개선 순서는 [로드맵 #27](https://github.com/juhwanz/eshop-refac/issues/27)에서 관리합니다.
+> 이 문서는 2026-09-09 기준 구현 상태와 검증 범위를 설명합니다. 운영 중인 서비스의 용량이나 SLO를 나타내지 않으며, 작업 이력은 [로드맵 #27](https://github.com/juhwanz/eshop-refac/issues/27)에서 확인할 수 있습니다.
 
 ## 핵심 설계
 
 | 관심사 | 현재 구현 | 지키려는 조건 |
 |---|---|---|
-| 재고 동시성 | 상품별 Redisson 분산 락 | 재고가 음수가 되거나 초과 판매되지 않음 |
+| 재고 동시성 | 상품별 Redisson 분산 락, 도메인 검증, DB CHECK | 지원 주문 경로의 동시 차감 직렬화와 음수 재고 저장 차단 |
 | 트랜잭션 경계 | 락 획득 후 `OrderService` 트랜잭션 진입 | 락 대기 중 DB 커넥션을 점유하지 않음 |
-| 주문 멱등성 | Redis `setIfAbsent`, 처리 상태 및 응답 TTL | 완료 요청은 기존 응답 반환, 실패 요청은 재시도 허용 |
+| 주문 멱등성 | Redis 처리 표시·응답 캐시, `(user_id, idempotency_key)` DB 유일 제약 | 완료 요청은 기존 DB 결과 복구, 실패 요청은 재시도 허용 |
 | 유량 제어 | 상품별 Redis ZSet admission queue와 TTL 활성 권한 | 다른 상품의 혼잡 격리, 주문 상품과 권한 일치 |
 | 캐시 정합성 | `AFTER_COMMIT` 이벤트 기반 상품 캐시 제거 | DB 롤백 시 캐시를 먼저 제거하지 않음 |
 | 상품 조회 | QueryDSL Offset `Page` + No-Offset `Slice` | 페이지 이동과 커서 조회 요구를 분리 |
 | 주문 조회 | `default_batch_fetch_size=100` | 페이징을 유지하면서 연관 항목을 묶어서 조회 |
-| 인증 | Stateless JWT, Refresh Token Rotation, Redis blacklist | 토큰 재사용과 로그아웃 토큰 접근 방지 |
+| 인증 | Stateless JWT, Refresh Token Rotation, Redis blacklist | Refresh Token 교체와 로그아웃한 Access Token 거부 |
 
 ```mermaid
 flowchart LR
@@ -176,23 +176,24 @@ Spring Boot는 `docker-compose.dev.yml`의 Redis를 자동으로 시작하고 �
 
 `integrationTest`는 로컬이나 CI에 MariaDB·Redis를 미리 실행하지 않아도 됩니다. Testcontainers가 실행 환경의 Docker로 격리된 컨테이너를 시작합니다. 테스트 분리 기준, 재현 방법과 기존 실험 결과는 [테스트와 검증](docs/testing.md)을 참고하세요.
 
-상품 대기열 기반 주문·조회 부하는 로컬 baseline 3회에서 모두 재고 정합성을 지켰습니다. 실행 조건, p95, 오류율과 회귀 감지용 threshold는 [k6 부하 테스트](docs/load-testing.md)에서 확인할 수 있으며 이 기준은 운영 SLO가 아닙니다.
+상품 대기열 기반 주문·조회 부하는 기록된 commit과 로컬 환경에서 baseline 3회를 수행했고, 각 실행의 성공 주문 수와 최종 재고가 일치했습니다. 실행 조건, p95, 오류율과 로컬 회귀 감지용 threshold는 [k6 부하 테스트](docs/load-testing.md)에서 확인할 수 있으며 이 결과는 운영 용량이나 SLO가 아닙니다.
 
-## 배포 구성
+## 이미지 게시와 참고용 배포 구성
 
 - `Dockerfile`: JDK 21 빌더와 JRE 21 런타임을 분리한 multi-stage 이미지
-- `docker-compose.prod.yml`: Redis와 blue/green 애플리케이션 컨테이너 정의
-- `deploy.sh`: 새 컨테이너 실행, Nginx upstream 전환, 이전 컨테이너 종료
+- `docker-compose.prod.yml`: Redis와 blue/green 애플리케이션 컨테이너를 정의한 참고용 Compose
+- `deploy.sh`: 새 컨테이너 실행, 고정 대기, Nginx upstream 전환과 이전 컨테이너 종료를 순서대로 수행하는 참고용 스크립트
 
-현재 CI는 Docker 이미지 게시까지만 자동화합니다. `deploy.sh`를 원격 서버에서 실행하는 단계는 GitHub Actions에 연결되어 있지 않습니다.
+현재 자동화 범위는 CI 검증과 Docker 이미지 게시까지입니다. 실제 운영 배포 환경은 없으며 `docker-compose.prod.yml`과 `deploy.sh`는 GitHub Actions에 연결되거나 운영에서 검증된 배포 경로가 아닙니다. 특히 `deploy.sh`의 고정 대기는 애플리케이션 준비 상태, 무중단 전환 또는 실패 시 rollback을 보장하지 않습니다.
 
 운영 프로필은 `DB_PASSWORD`와 `JWT_SECRET_KEY`가 비어 있으면 기동에 실패합니다. Actuator는 `/actuator/health`만 노출하며, 그 외 운영 endpoint는 외부 요청을 차단합니다.
 
-## 현재 상태와 다음 개선
+## 현재 상태와 범위
 
-- 완료: 자격 증명 정리와 저장소 이력 정제([#8](https://github.com/juhwanz/eshop-refac/issues/8), [#9](https://github.com/juhwanz/eshop-refac/issues/9))
-- 다음 보안 작업: 운영 설정 fail-fast와 Actuator 접근 정책([#14](https://github.com/juhwanz/eshop-refac/issues/14))
-- 검증 기반: MariaDB·Redis Testcontainers 도입 후 CI 통합 테스트 연결([#16](https://github.com/juhwanz/eshop-refac/issues/16), [#15](https://github.com/juhwanz/eshop-refac/issues/15))
+- 저장소·보안 기반: 자격 증명 정리, 운영 secret fail-fast와 Actuator 최소 공개를 완료했습니다([#8](https://github.com/juhwanz/eshop-refac/issues/8), [#9](https://github.com/juhwanz/eshop-refac/issues/9), [#14](https://github.com/juhwanz/eshop-refac/issues/14)).
+- 검증 기반: MariaDB·Redis Testcontainers를 도입하고 `main` CI에 통합 테스트를 연결했습니다([#16](https://github.com/juhwanz/eshop-refac/issues/16), [#15](https://github.com/juhwanz/eshop-refac/issues/15)).
+- 핵심 PoC: 주문 취소·재고·멱등성, 임시 로그인 잠금과 상품 단위 대기열을 회귀 테스트로 검증했습니다([로드맵 #27](https://github.com/juhwanz/eshop-refac/issues/27)).
+- 성능 증거: 상품 대기열 기반 주문·조회 workload의 로컬 반복 결과만 유지합니다([#17](https://github.com/juhwanz/eshop-refac/issues/17)). 실제 운영 데이터와 병목이 없어 합성 데이터 기반 인덱스 튜닝은 수행하지 않았습니다([#25](https://github.com/juhwanz/eshop-refac/issues/25)).
 - 스키마: 실제 운영 데이터가 없는 현재 단계에서는 `local`, `prod` 모두 Hibernate `ddl-auto: update`로 관리합니다. 전환 배경과 재검토 조건은 [#33](https://github.com/juhwanz/eshop-refac/issues/33)에 정리되어 있습니다.
 
 ## 상세 문서

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# 참고용 수동 배포 스크립트입니다. 현재 GitHub Actions나 운영 서버에 연결되어 있지 않습니다.
+# 고정 대기 후 전환하므로 애플리케이션 readiness, 무중단 전환, 실패 시 rollback을 보장하지 않습니다.
+
 # 1. 현재 실행 중인 교대 근무자(컨테이너) 확인
 IS_GREEN=$(sudo docker ps | grep eshop-green)
 
@@ -22,15 +25,15 @@ sudo docker-compose -f docker-compose.prod.yml pull $TARGET_UP
 echo "2. 새 컨테이너($TARGET_UP) 실행"
 sudo docker-compose -f docker-compose.prod.yml up -d $TARGET_UP
 
-# 3. 스프링 부트가 완전히 켜질 때까지 안전하게 대기 (Health Check 대용)
-echo "3. 15초 대기 (스프링 부트 부팅 시간)..."
+# 3. 참고용 고정 대기 (readiness 확인이 아님)
+echo "3. 15초 고정 대기 (readiness 확인 없음)..."
 sleep 15
 
 # 4. Nginx가 바라보는 포트 스위칭 (동적 라우팅)
 echo "4. Nginx 프록시 포트를 $TARGET_PORT 로 스위칭"
 echo "set \$service_url http://127.0.0.1:$TARGET_PORT;" | sudo tee /etc/nginx/conf.d/service-url.inc
 
-echo "5. Nginx 리로드 (단 0.1초의 멈춤 없이 트래픽 전환)"
+echo "5. Nginx 리로드"
 sudo systemctl reload nginx
 
 # 5. 임무를 마친 구형 컨테이너 종료 및 삭제
@@ -38,4 +41,4 @@ echo "6. 기존 컨테이너($TARGET_DOWN) 종료"
 sudo docker-compose -f docker-compose.prod.yml stop $TARGET_DOWN
 sudo docker-compose -f docker-compose.prod.yml rm -f $TARGET_DOWN
 
-echo "### 무중단 배포 완벽하게 성공 ###"
+echo "### 참고용 배포 절차 완료 ###"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,3 +1,4 @@
+# 참고용 배포 구성입니다. 현재 GitHub Actions나 운영 환경에서 실행·검증되는 배포 경로가 아닙니다.
 services:
   # 1. 공통 캐시 서버 (Redis)
   redis:

--- a/docs/security/credential-management.md
+++ b/docs/security/credential-management.md
@@ -16,15 +16,17 @@
 - `DB_USERNAME`: 데이터베이스 사용자
 - `DB_PASSWORD`: 데이터베이스 비밀번호
 - `JWT_SECRET_KEY`: Base64로 인코딩된 256비트 이상의 무작위 JWT 서명키
-- `RDS_HOST`: 운영 Compose를 사용할 때의 데이터베이스 호스트
+- `RDS_HOST`: 참고용 `docker-compose.prod.yml`을 사용할 때의 데이터베이스 호스트
 
 `.env`와 `src/main/resources/application-secret.yaml`은 Git에 추가하지 않는다. 실제 값을 예시 파일에 복사하지 않는다. 공유 시스템에서는 `chmod 600 .env`로 파일을 현재 사용자만 읽고 쓸 수 있게 제한한다.
 
-## 운영 배포
+## 배포 환경을 구성할 때의 요구사항
 
-- 운영 DB에는 관리자 계정 대신 애플리케이션 전용 계정을 사용한다.
-- EC2의 `.env`는 배포 사용자만 읽을 수 있도록 권한을 제한한다.
-- Docker Hub access token과 EC2 SSH key는 GitHub Actions secret으로 관리한다.
+현재 원격 운영 서버와 자동 배포 경로는 없다. `docker-compose.prod.yml`과 `deploy.sh`는 운영에서 검증된 구성이 아니라 향후 배포 환경을 설계할 때 검토할 참고 자료다.
+
+- 실제 운영 DB에는 관리자 계정 대신 애플리케이션 전용 계정을 사용한다.
+- 배포 서버의 `.env`는 배포 사용자만 읽을 수 있도록 권한을 제한한다.
+- Docker Hub access token은 현재 이미지 게시 workflow의 GitHub Actions secret으로 관리한다. SSH key는 원격 배포가 도입될 때 대상과 권한을 정한 뒤 별도로 관리한다.
 - 자격 증명을 교체할 때는 새 값 배포와 상태 확인을 마친 뒤 기존 값을 폐기한다.
 - `prod` 프로필은 `DB_PASSWORD`와 `JWT_SECRET_KEY`가 없거나 공백이면 명확한 오류와 함께 기동을 중단한다.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -46,16 +46,16 @@ Testcontainers가 `mariadb:11.8.6`과 `redis:7.4.5-alpine`을 시작하고 동�
 
 | 테스트 | 검증 대상 |
 |---|---|
-| `OrderConcurrencyIntegrationTest` | 동시 주문 시 성공/실패 수와 최종 재고, DB 락과 Redis 락 비교 |
-| `OrderAvailabilityIntegrationTest` | 주문 경합 중 조회 요청의 생존 여부 |
+| `OrderConcurrencyIntegrationTest` | 동시 주문 시 성공/실패 수와 최종 재고 |
+| `OrderAvailabilityIntegrationTest` | 제한된 커넥션 풀에서 락 대기 위치에 따른 조회 성공·실패 조건 |
 | `OrderIdempotencyTest` | 동일 사용자·동일 키 재요청이 기존 주문 응답을 반환하는지 |
 | `OrderQueryIntegrationTest` | 주문 목록의 연관 항목과 상품이 제한된 SQL 수로 batch fetch되는지 |
 | `ProductCacheIntegrationTest` | Cache Miss → Put → AFTER_COMMIT Evict → 최신 값 재조회 |
 | `ProductRepositoryIntegrationTest` | QueryDSL 조건 검색과 No-Offset 커서 경계 |
 
-## 기존 실험 결과
+## 검증 사례와 성능 증거
 
-아래 값은 저장소 테스트를 개발 환경에서 실행했을 때 기록한 사례입니다. 고정된 CI benchmark가 아니므로 하드웨어, 데이터 분포, JVM warm-up과 실행 시점에 따라 절대값이 달라질 수 있습니다.
+아래 정합성·가용성 사례는 테스트가 판정하는 조건을 설명합니다. 경과 시간은 하드웨어, JVM 상태와 실행 시점에 따라 달라지고 합격 조건이 아니므로 성능 근거로 사용하지 않습니다. 반복 가능한 성능 자료는 실행 환경과 commit을 기록한 [#17](https://github.com/juhwanz/eshop-refac/issues/17)의 k6 결과만 사용합니다.
 
 ### 재고 정합성
 
@@ -67,23 +67,14 @@ Testcontainers가 `mariadb:11.8.6`과 `redis:7.4.5-alpine`을 시작하고 동�
 
 핵심 판정은 처리 시간보다 성공 수와 최종 재고가 초기 재고를 위반하지 않는지입니다.
 
-### 주문 경합 중 조회 가용성
+### 제한된 커넥션 풀의 조회 가용성
 
-| 방식 | 관찰된 총 소요 시간 | 조회 성공 | 조회 실패 |
-|---|---:|---:|---:|
-| DB 비관적 락 | 418ms | 0 | 20 |
-| Redis 분산 락 | 8,766ms | 20 | 0 |
+| 시나리오 | 테스트에서 확인하는 조건 |
+|---|---|
+| DB 비관적 락 트랜잭션이 5개 커넥션을 모두 점유 | 별도 조회 20건이 connection timeout으로 실패 |
+| Redis 락 대기가 DB 트랜잭션 밖에서 발생 | 별도 조회 20건이 connection timeout 없이 완료 |
 
-테스트는 DB 경로에서 비관적 락 트랜잭션이 작은 커넥션 풀 전체를 점유하도록 동기화하고, Redis 경로에는 AOP 지연을 주입해 락 대기가 트랜잭션 밖에서 발생하도록 재현합니다. 이 결과는 Redis 방식이 무조건 빠르다는 뜻이 아니라, 락 대기를 DB 밖으로 옮겼을 때 조회 커넥션을 보존할 수 있음을 보여줍니다.
-
-### 락 비용 비교 사례
-
-| 비교 | DB 비관적 락 | Redis 분산 락 |
-|---|---:|---:|
-| 순수 락 오버헤드 | 199ms | 432ms |
-| 전체 주문 흐름 | 67ms | 456ms |
-
-서로 수행 범위가 완전히 같은 운영 benchmark는 아닙니다. 현재 성능 기준은 동일 workload로 반복 실행한 [#17](https://github.com/juhwanz/eshop-refac/issues/17)의 결과만 사용하며, 실제 운영 용량이나 서로 다른 락 전략의 속도 우열로 해석하지 않습니다.
+테스트는 두 경로의 처리 속도를 비교하지 않습니다. 의도적으로 작게 제한한 커넥션 풀에서 락 대기를 DB 트랜잭션 밖에 두는 경계가 조회용 커넥션을 남기는지만 확인합니다. 이 결과를 운영 가용성이나 DB 락과 Redis 락의 속도 우열로 해석하지 않습니다.
 
 ## GitHub Actions
 

--- a/src/main/java/com/project/eshop_refact/domain/order/RedissonLockStockFacade.java
+++ b/src/main/java/com/project/eshop_refact/domain/order/RedissonLockStockFacade.java
@@ -15,8 +15,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.Optional;
 
 /**
- * 분산 락(Redisson) 기반 재고 동시성 제어 파사드
- * 트랜잭션 진입 전 락을 제어하여 DB 커넥션 점유 시간을 최소화하고, Pub/Sub 기반 구현체로 Redis 부하를 완화합니다.
+ * 분산 락(Redisson) 기반 재고 동시성 제어 파사드입니다.
+ * 상품 락을 획득한 뒤 트랜잭션 서비스를 호출하여 락 대기 중에는 DB 커넥션을 점유하지 않습니다.
  */
 @Slf4j
 @Component

--- a/src/main/java/com/project/eshop_refact/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/eshop_refact/global/security/JwtAuthenticationFilter.java
@@ -56,7 +56,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // Refresh Token이 인증(API 접근) 용도로 오용되는 것을 방지하기 위해 Access Token을 명시적으로 확인합니다.
             if (claims != null && "ACCESS".equals(claims.get("type"))) {
 
-                // Redis 블랙리스트를 조회하여 로그아웃 처리된 토큰의 탈취 및 재사용을 원천 차단합니다.
+                // Redis 블랙리스트에 등록된 로그아웃 Access Token의 인증 요청을 거부합니다.
                 String isLogout = redisTemplate.opsForValue().get("BLACKLIST:" + token);
                 if(StringUtils.hasText(isLogout)){
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그아웃된 토큰입니다");

--- a/src/test/java/com/project/eshop_refact/integration/OrderAvailabilityIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/OrderAvailabilityIntegrationTest.java
@@ -28,14 +28,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * DB 커넥션 풀 고갈(Connection Pool Starvation) 시나리오 및 가용성(Availability) 검증 테스트
- * * [시뮬레이션 환경 제약]
+ * 제한된 DB 커넥션 풀에서 락 대기 위치에 따른 조회 성공·실패 조건을 검증합니다.
+ * [테스트 시뮬레이션 조건]
  * 1. hikari.maximum-pool-size=5 : 커넥션 풀을 극단적으로 제한
  * 2. hikari.connection-timeout=250 : 0.25초 내 커넥션 획득 실패 시 에러 발생
  * 3. DB 경로는 비관적 락 트랜잭션 5개가 풀을 점유한 뒤 조회를 시작하도록 동기화
  * 4. test.simulation.delay-ms=150 : Redis 락 경로의 트랜잭션 내부 로직에 지연 주입
- * * 트래픽 폭주 상황에서 'DB 비관적 락(점유 시간 증가)'과 'Redis 분산 락'의
- * 시스템 전체 가용성(단순 조회 요청의 성공 여부) 차이를 증명합니다.
+ * 실제 운영 부하나 두 락 방식의 처리 속도를 비교하지 않습니다.
  */
 @SpringBootTest(properties = {
         "spring.datasource.hikari.maximum-pool-size=5",
@@ -69,12 +68,11 @@ public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTes
     }
 
     @Test
-    @DisplayName("서버 생존 테스트: 주문 폭주 시 DB락과 Redis락 비교")
+    @DisplayName("제한된 커넥션 풀에서 트랜잭션 밖의 Redis 락 대기는 조회 커넥션을 점유하지 않는다")
     void compareAvailability() throws InterruptedException {
         // [1] DB 비관적 락 시나리오 검증
         // 비관적 락을 획득한 트랜잭션이 커넥션 풀 전체를 점유하도록 동기화합니다.
-        // 이로 인해 락과 무관한 '단순 조회' 요청마저 커넥션 타임아웃으로 실패해야 합니다.
-        System.out.println("\n========== [1. DB 비관적 락 테스트 시작] ==========");
+        // 설정한 시나리오에서는 락과 무관한 조회도 커넥션 타임아웃으로 실패합니다.
         int dbViewFailCount = runDbLockTest();
 
         assertThat(dbViewFailCount).isEqualTo(VIEW_COUNT);
@@ -82,16 +80,15 @@ public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTes
         tearDown();
 
         // [2] Redis 분산 락 시나리오 검증
-        // DB 트랜잭션 진입 전 Redis에서 대기열을 제어하므로, DB 커넥션 점유 시간이 짧게 유지됩니다.
-        // 따라서 '단순 조회' 요청이 커넥션 풀의 여유분을 확보하여 타임아웃 없이 정상 처리되어야 합니다.
-        System.out.println("\n========== [2. Redis 분산 락 테스트 시작] ==========");
+        // Redis 락 대기는 DB 트랜잭션 진입 전에 발생하므로 조회가 사용할 커넥션을 점유하지 않습니다.
         TestResult redisResult = runRedisLockTest();
 
         assertThat(redisResult.remainingStock()).isBetween(50,55);
+        assertThat(redisResult.viewSuccessCount()).isEqualTo(VIEW_COUNT);
         assertThat(redisResult.viewFailCount()).isEqualTo(0);
     }
 
-    record TestResult(int remainingStock, int viewFailCount) {
+    record TestResult(int remainingStock, int viewSuccessCount, int viewFailCount) {
     }
 
     private void holdPessimisticLock(
@@ -122,8 +119,6 @@ public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTes
         CountDownLatch viewTasksDone = new CountDownLatch(VIEW_COUNT);
         AtomicInteger viewFail = new AtomicInteger();
 
-        long start = System.currentTimeMillis();
-
         try {
             for (Long lockTargetId : lockTargetIds) {
                 executor.submit(() -> {
@@ -145,7 +140,6 @@ public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTes
 
         assertThat(lockTasksDone.await(2, TimeUnit.MINUTES)).isTrue();
 
-        printResult("DB 비관적 락", start, VIEW_COUNT - viewFail.get(), viewFail.get());
         return viewFail.get();
     }
 
@@ -161,8 +155,6 @@ public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTes
 
         AtomicInteger viewSuccess = new AtomicInteger();
         AtomicInteger viewFail = new AtomicInteger();
-
-        long start = System.currentTimeMillis();
 
         try {
             // 1. 재고 차감(동시성) 트래픽 발생
@@ -192,9 +184,7 @@ public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTes
         }
 
         Product finalProduct = productRepository.findById(product.getId()).orElseThrow();
-        printResult("Redis 분산 락", start, viewSuccess.get(), viewFail.get());
-
-        return new TestResult(finalProduct.getStockQuantity(), viewFail.get());
+        return new TestResult(finalProduct.getStockQuantity(), viewSuccess.get(), viewFail.get());
     }
 
     private void submitViewTasks(
@@ -222,13 +212,6 @@ public class OrderAvailabilityIntegrationTest extends MariaDbRedisIntegrationTes
                 }
             });
         }
-    }
-
-    private void printResult(String method, long start, int viewSuccess, int viewFail) {
-        System.out.println("  [" + method + " 결과]");
-        System.out.println("   - 총 소요 시간: " + (System.currentTimeMillis() - start) + "ms");
-        System.out.println("   - 조회 성공: " + viewSuccess);
-        System.out.println("   - 조회 실패: " + viewFail);
     }
 
     private void await(CountDownLatch latch, String message) {

--- a/src/test/java/com/project/eshop_refact/integration/OrderConcurrencyIntegrationTest.java
+++ b/src/test/java/com/project/eshop_refact/integration/OrderConcurrencyIntegrationTest.java
@@ -7,14 +7,10 @@ import com.project.eshop_refact.domain.user.UserRoleEnum;
 import com.project.eshop_refact.domain.order.OrderRepository;
 import com.project.eshop_refact.domain.product.ProductRepository;
 import com.project.eshop_refact.domain.user.UserRepository;
-import com.project.eshop_refact.domain.order.OrderService;
-import com.project.eshop_refact.domain.order.strategy.PessimisticLockStrategy;
 import com.project.eshop_refact.integration.support.MariaDbRedisIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -28,12 +24,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * 대규모 동시성 트래픽 통합 테스트 및 락 메커니즘 성능 분석
- * 1. 초과 요청(경합) 발생 시의 재고 정합성(Concurrency Limit) 검증
- * 2. DB 비관적 락(Pessimistic)과 Redis 분산 락(Redisson) 간의 처리 시간 및 안정성 트레이드오프 비교
+ * 제한된 동시 주문 시나리오에서 성공·실패 수와 최종 재고를 검증합니다.
  */
 @SpringBootTest(properties = {
-        // 실제 운영 환경과 유사한 락 대기 상황 연출을 위해 타임아웃 설정
+        // 테스트 스레드가 락 획득 결과를 기다릴 수 있도록 한 테스트 전용 설정입니다.
         "spring.datasource.hikari.maximum-pool-size=50",
         "spring.datasource.hikari.connection-timeout=5000",
         "spring.jpa.properties.hibernate.show_sql=false",
@@ -42,14 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 })
 public class OrderConcurrencyIntegrationTest extends MariaDbRedisIntegrationTest {
 
-    @Autowired private OrderService orderService;
     @Autowired private RedissonLockStockFacade redissonLockStockFacade;
     @Autowired private UserRepository userRepository;
     @Autowired private ProductRepository productRepository;
     @Autowired private OrderRepository orderRepository;
-
-    @Autowired private PessimisticLockStrategy pessimisticLockStrategy;
-    @Autowired private RedissonClient redissonClient;
 
     @AfterEach
     void tearDown() {
@@ -113,110 +103,4 @@ public class OrderConcurrencyIntegrationTest extends MariaDbRedisIntegrationTest
         assertThat(updatedProduct.getStockQuantity()).isEqualTo(0);
     }
 
-    @Test
-    @DisplayName("[순수 락 성능 비교] DB Pessimistic Vs Redis (1:1)")
-    void comparePureLockPerformance() throws InterruptedException {
-        tearDown();
-        long dbLockTime = testConcurrency(
-                "DB 비관적 락",
-                (userId, productId) -> pessimisticLockStrategy.decrease(productId, 1)
-        );
-
-        tearDown();
-        long redisLockTime = testConcurrency(
-                "Redis 분산 락",
-                (userId, productId) -> {
-                    RLock lock = redissonClient.getLock("test:perf:pure:" + productId);
-                    try{
-                        boolean available = lock.tryLock(30, -1, TimeUnit.SECONDS);
-                        if(available){
-                            pessimisticLockStrategy.decrease(productId,1);
-                        }
-                    } catch(InterruptedException e){
-                        Thread.currentThread().interrupt();
-                    } finally {
-                        if(lock.isHeldByCurrentThread()){
-                            lock.unlock();
-                        }
-                    }
-                }
-        );
-
-        System.out.println("\n [성능 비교 결과 리포트]");
-        System.out.println(" - DB 비관적 락 소요 시간: " + dbLockTime + "ms");
-        System.out.println(" - Redis 분산 락 소요 시간: " + redisLockTime + "ms");
-        System.out.println(" - 결과: " + calculateDiff(dbLockTime, redisLockTime));
-    }
-
-    @Test
-    @DisplayName("[아키텍쳐 성능 비교] DB 비관적 락 Vs Redis 분산 락")
-    void compareArchitecturePerformance() throws InterruptedException{
-        tearDown();
-
-        long dbLockTime = testConcurrency(
-                "DB Pessimistic Lock",
-                (userId, productId) -> pessimisticLockStrategy.decrease(productId, 1)
-        );
-
-        tearDown();
-
-        long redisLockTime = testConcurrency(
-                "Redis Lock",
-                // 분산 환경의 가용성을 위해 트랜잭션 커밋 범위를 확장한 Facade 로직 수행
-                (userId, productId) -> redissonLockStockFacade.order(userId, productId, 1)
-        );
-
-        System.out.println("\n [ 아키텍처 성능 비교 (전체 주문 로직)]");
-        System.out.println(" - DB 락 (단순 차감): " + dbLockTime + "ms");
-        System.out.println(" - Redis 락 (전체 주문): " + redisLockTime + "ms");
-        System.out.println(" - 결과: " + calculateDiff(dbLockTime, redisLockTime) + " (트랜잭션 범위 확장에 따른 Trade-off)");
-        System.out.println("=============================================\n");
-
-    }
-    // 중복 코드를 제거한 테스트 실행기
-    private long testConcurrency(String testName, OrderTask task) throws InterruptedException {
-        // Given
-        int stockQuantity = 100;
-        int threadCount = 100;
-
-        Product product = productRepository.save(new Product("Test Item", 10000, stockQuantity));
-        User user = userRepository.save(new User("tester@test.com", "1234", "tester", UserRoleEnum.USER));
-
-        ExecutorService executorService = Executors.newFixedThreadPool(32);
-        CountDownLatch latch = new CountDownLatch(threadCount);
-
-        long startTime = System.currentTimeMillis();
-
-        for (int i = 0; i < threadCount; i++) {
-            executorService.submit(() -> {
-                try {
-                    task.run(user.getId(), product.getId());
-                } catch (Exception e) {
-                    // 성능 측정 오차를 줄이기 위해 예외 로깅 생략
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        assertThat(latch.await(2, TimeUnit.MINUTES)).isTrue();
-        executorService.shutdownNow();
-        return System.currentTimeMillis() - startTime;
-    }
-
-    @FunctionalInterface
-    interface OrderTask {
-        void run(Long userId, Long productId);
-    }
-
-    private String calculateDiff(long db, long redis) {
-        if (db == 0) return "0%";
-        double diff = ((double) (redis - db) / db) * 100;
-
-        if (diff > 0) {
-            return String.format("Redis가 DB보다 약 %.1f배 느림 (안정성 확보를 위한 Trade-off)", (redis / (double) db));
-        } else {
-            return String.format("Redis가 %.2f%% 더 빠름", Math.abs(diff));
-        }
-    }
 }


### PR DESCRIPTION
## 변경 내용
- README를 고트래픽 주문·재고 및 상품 대기열 PoC 범위로 정리
- 운영하지 않는 배포 구성과 참고용 스크립트의 상태 명시
- 재현 조건이 없는 락 성능 수치와 assertion 없는 timing 비교 테스트 제거
- 가용성 테스트와 보안·분산 락 설명을 검증 가능한 범위로 조정

## 검증
- ./gradlew verifyChange
- ./gradlew integrationTest --tests '*OrderConcurrencyIntegrationTest' --tests '*OrderAvailabilityIntegrationTest'
- bash -n deploy.sh scripts/check-repository-hygiene.sh scripts/prepare-load-test-product.sh scripts/prepare-load-test-users.sh
- Markdown 로컬 링크 대상 검사
- bash scripts/check-repository-hygiene.sh
- git diff --check

## 미실행
- 전체 integrationTest: 변경한 두 통합 테스트를 선별 실행
- k6 및 stressTest: 로컬 데이터 변경 범위이므로 미실행

Closes #26